### PR TITLE
[Chore]: build ci 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: CI-Build
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-pnpm build


### PR DESCRIPTION
## 관련 이슈
close: #37 

## 변경 사항

build ci를 추가했어요. 

현재는 프로젝트 규모가 작아 husky를 통한 pre-commit, pre-push가 문제가 없지만, 규모가 커질수록 긴 빌드 시간으로 인해 DX가 저하될 것이라 생각했어요.

나연님께서도 동의하신다면, husky에서 pre-commit, pre-push 파일도 이 PR에서 함께 삭제하도록 하겠습니다!


## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- GitHub Actions CI 빌드 워크플로우 추가
	- `main` 및 `develop` 브랜치에 대한 자동 빌드 프로세스 구현
	- 풀 리퀘스트 트리거 시 프로젝트 종속성 설치 및 빌드 자동화
- **변경 사항**
	- `.husky/pre-push` 파일 삭제로 인해 코드 푸시 전 빌드 및 검증이 수행되지 않음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->