### PR TITLE
[Feat] pnpm workspace 추가

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@repo/theme": "workspace:^",
+    "@repo/ui": "workspace:^",
     "next": "14.2.21",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@repo/theme": ["packages/theme/src"],
+      "@repo/ui": ["packages/ui/src"]
+    },
     "esModuleInterop": true,
     "incremental": false,
     "isolatedModules": true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "dependencies": {
+    "@repo/theme": "workspace:^",
     "@vanilla-extract/css": "^1.17.0",
     "@vanilla-extract/recipes": "^0.5.5",
     "react": "^18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@repo/theme':
+        specifier: workspace:^
+        version: link:../../packages/theme
+      '@repo/ui':
+        specifier: workspace:^
+        version: link:../../packages/ui
       next:
         specifier: 14.2.21
         version: 14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -154,6 +160,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@repo/theme':
+        specifier: workspace:^
+        version: link:../theme
       '@vanilla-extract/css':
         specifier: ^1.17.0
         version: 1.17.0


### PR DESCRIPTION
## 관련 이슈
close #41

## 변경 사항
@repo/ui에서는 @repo/theme을 사용할 수 있도록, web 앱에서는 @repo/ui, @repo/theme 모두 사용할 수 있도록 워크스페이스 처리 해 주었습니다! 자동 임포트도 잘 되어요!

<img width="469" alt="image" src="https://github.com/user-attachments/assets/0e71f005-b056-427c-bf94-d91469ccc41d" />

## 레퍼런스





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **의존성 업데이트**
	- 웹 애플리케이션에 `@repo/theme` 및 `@repo/ui` 패키지 추가
	- 개발 의존성으로 `@repo/eslint-config`와 `@repo/typescript-config` 통합
	- TypeScript 구성에 모듈 경로 매핑 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->