### PR TITLE
[Feat]: theme 적용을 위한 Provider 추가

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
-//import '@repo/ui/styles';
 import '@repo/theme/styles';
+//import '@repo/ui/styles';
+import { ThemeProvider } from '@repo/theme';
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -28,7 +29,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <ThemeProvider theme="light">{children}</ThemeProvider>{' '}
+        {/** TODO: 추후 시스템 감지 설정 추가 예정 */}
       </body>
     </html>
   );

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -18,9 +18,11 @@
     "@vanilla-extract/css": "^1.17.0",
     "@vanilla-extract/next-plugin": "^2.4.8",
     "@vanilla-extract/recipes": "^0.5.5",
-    "@vanilla-extract/sprinkles": "^1.6.3"
+    "@vanilla-extract/sprinkles": "^1.6.3",
+    "react": "^18"
   },
   "devDependencies": {
+    "@types/react": "^18.2.0",
     "@vanilla-extract/esbuild-plugin": "^2.3.5",
     "esbuild": "^0.21.0",
     "esbuild-plugin-preserve-directives": "^0.0.11"

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { lightThemeClass, darkThemeClass } from '../themes/themes.css';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  theme?: 'light' | 'dark';
+}
+
+export function ThemeProvider({
+  children,
+  theme = 'light',
+}: ThemeProviderProps) {
+  const themeClass = theme === 'light' ? lightThemeClass : darkThemeClass;
+
+  return <div className={themeClass}>{children}</div>;
+}

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { lightThemeClass, darkThemeClass } from '../themes/themes.css';
 
-interface ThemeProviderProps {
-  children: React.ReactNode;
+type ThemeProviderProps = {
+  children: ReactNode;
   theme?: 'light' | 'dark';
-}
+};
 
 export function ThemeProvider({
   children,

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,3 +1,4 @@
-export * from './tokens';
 export * from './themes';
 export * from './sprinkles';
+export * from './tokens';
+export * from './components/ThemeProvider';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,13 @@ importers:
       '@vanilla-extract/sprinkles':
         specifier: ^1.6.3
         version: 1.6.3(@vanilla-extract/css@1.17.0)
+      react:
+        specifier: ^18
+        version: 18.3.1
     devDependencies:
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.0
       '@vanilla-extract/esbuild-plugin':
         specifier: ^2.3.5
         version: 2.3.13(@types/node@20.17.6)(esbuild@0.21.5)(terser@5.37.0)
@@ -1793,6 +1799,7 @@ packages:
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}


### PR DESCRIPTION
## 관련 이슈

close: #46 

## 변경 사항

색상 테마 적용을 위해 @repo/theme에서 ThemeProvider를 만들어 export하고, apps/web에서 사용해요.

우선적으로 light 테마로 적용하고 개발 시작하고, 추후 시스템에 따른 테마 적용 또는 토글로 테마 적용을 구현할 예정이에요.

## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 애플리케이션에 테마 제공자(Theme Provider) 기능 추가
  - 기본적으로 라이트 테마 설정 지원

- **개선 사항**
  - 레이아웃 컴포넌트에 테마 설정 기능 통합
  - 향후 시스템 테마 감지 설정을 위한 기반 마련

- **의존성 추가**
  - React 및 TypeScript 타입 정의 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->