### PR TITLE
[Fix]: Icon 컴포넌트 수정

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,10 +1,17 @@
 import { Icon } from '@repo/ui';
-
+import { tokens } from '@repo/theme';
 export default function Home() {
   return (
     <div>
       웹 1팀 파이팅!
-      <Icon width={100} height={100} name="stack" fill="blue" />
+      <Icon size={24} name="stack" type="stroke" />
+      <Icon size={24} name="stack" type="fill" />
+      <Icon
+        size={24}
+        name="stack"
+        type="stroke"
+        color={tokens.colors.warning300}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/Icon/Icon.tsx
+++ b/packages/ui/src/components/Icon/Icon.tsx
@@ -25,14 +25,16 @@ export function Icon({
 }: IconProps) {
   const SVG = icons[name];
 
+  const colorStyle = {
+    ...(type !== 'stroke' && { [styles.fillColor]: color }),
+    ...(type !== 'fill' && { [styles.strokeColor]: color }),
+  };
+
   return (
     <SVG
       className={styles.parent}
       style={{
-        ...assignInlineVars({
-          [styles.strokeColor]: type === 'fill' ? 'none' : color,
-          [styles.fillColor]: type === 'stroke' ? 'none' : color,
-        }),
+        ...assignInlineVars(colorStyle),
         width: size,
         height: size,
         ...iconStyle,

--- a/packages/ui/src/components/Icon/Icon.tsx
+++ b/packages/ui/src/components/Icon/Icon.tsx
@@ -1,40 +1,45 @@
-import { FC, SVGProps } from 'react';
+import { SVGProps } from 'react';
 import { icons } from './assets';
 import { tokens } from '@repo/theme';
 import * as styles from './Icon.css';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-type IconName = keyof typeof icons;
+export type IconName = keyof typeof icons;
 
-interface IconProps extends SVGProps<SVGSVGElement> {
+export type IconProps = SVGProps<SVGSVGElement> & {
   name: IconName;
-  fill?: keyof typeof tokens.colors;
-  stroke?: keyof typeof tokens.colors;
-}
+  type?: 'fill' | 'stroke';
+  color?: (typeof tokens.colors)[keyof typeof tokens.colors];
+  size?: number | string;
+  'aria-label'?: string;
+};
 
-export const Icon: FC<IconProps> = ({
+export function Icon({
   name,
-  stroke,
-  fill,
-  ...rest
-}: IconProps) => {
-  const SVG = icons[name] as FC<SVGProps<SVGSVGElement>>;
-
-  const resolvedFill = fill ? tokens.colors[fill] : 'transparent';
-  const resolvedStroke = stroke ? tokens.colors[stroke] : 'transparent';
+  type = 'fill',
+  color = tokens.colors.grey300,
+  size = 24,
+  style: iconStyle,
+  'aria-label': ariaLabel,
+  ...restProps
+}: IconProps) {
+  const SVG = icons[name];
 
   return (
     <SVG
       className={styles.parent}
-      style={JSON.parse(
-        JSON.stringify(
-          assignInlineVars({
-            [styles.strokeColor]: resolvedStroke,
-            [styles.fillColor]: resolvedFill,
-          })
-        )
-      )}
-      {...rest}
+      style={{
+        ...assignInlineVars({
+          [styles.strokeColor]: type === 'fill' ? 'none' : color,
+          [styles.fillColor]: type === 'stroke' ? 'none' : color,
+        }),
+        width: size,
+        height: size,
+        ...iconStyle,
+      }}
+      role="img"
+      aria-label={ariaLabel}
+      {...restProps}
     />
   );
-};
+}

--- a/packages/ui/src/components/Icon/Icon.tsx
+++ b/packages/ui/src/components/Icon/Icon.tsx
@@ -9,7 +9,7 @@ export type IconName = keyof typeof icons;
 export type IconProps = SVGProps<SVGSVGElement> & {
   name: IconName;
   type?: 'fill' | 'stroke';
-  color?: (typeof tokens.colors)[keyof typeof tokens.colors];
+  color?: string;
   size?: number | string;
   'aria-label'?: string;
 };

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './Spacing/Spacing';
-export * from './Icon/Icon';
+export { Icon } from './Icon/Icon';
+export type { IconName, IconProps } from './Icon/Icon';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,6 +6,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
+    "rootDir": "src",
     "outDir": "./dist",
     "declaration": true
   },


### PR DESCRIPTION
## 관련 이슈
Icon 컴포넌트의 prop 타입을 export 하지 않고 있었고, 불필요한 직렬화/역직렬화 과정을 개선했어요. 그리고 조금 더 사용성이 좋도록 api를 개선했어요. 

React.FC 유틸 타입을 사용하면 children이 암묵적으로 optional하게 적용될 수 있어서 변경했어요.


## 변경 사항
<img width="613" alt="image" src="https://github.com/user-attachments/assets/8d0de9a9-3d82-4a50-aa52-0a6ad7843fce" />
<img width="427" alt="image" src="https://github.com/user-attachments/assets/e6d89490-b3f0-4617-b32f-ca2b582a8897" />

## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 아이콘 컴포넌트의 유연성 향상
	- 테마 토큰을 사용한 아이콘 색상 관리 개선

- **개선 사항**
	- 아이콘 렌더링을 위한 새로운 속성 추가 (`size`, `type`, `color`)
	- 접근성 향상을 위한 아리아 레이블 및 역할 속성 추가

- **기술적 변경**
	- 컴포넌트 내보내기 방식 최적화
	- TypeScript 컴파일러 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->