### PR TITLE
[Chore] theme color 업데이트, 타입 export

### DIFF
--- a/packages/theme/src/themes/contract.ts
+++ b/packages/theme/src/themes/contract.ts
@@ -31,6 +31,26 @@ export type ThemeContract = {
     grey100to700Hover: string;
     grey950toPrimary: string;
     grey1000to1000: string;
+
+    primary500: string;
+    primary600: string;
+    primary700: string;
+    primary800: string;
+
+    shadow: string;
+    blue: string;
+
+    pink200: string;
+    pink400: string;
+    pink800: string;
+
+    orange200: string;
+    orange400: string;
+    orange800: string;
+
+    blue200: string;
+    blue400: string;
+    blue800: string;
   };
   space: {
     [K in keyof typeof tokens.spacing]: string;

--- a/packages/theme/src/themes/dark.ts
+++ b/packages/theme/src/themes/dark.ts
@@ -35,6 +35,26 @@ export const darkTheme: ThemeContract = {
     grey100to700Hover: tokens.colors.grey600,
     grey950toPrimary: tokens.colors.green200,
     grey1000to1000: tokens.colors.grey1000,
+
+    primary500: tokens.colors.primary500,
+    primary600: tokens.colors.primary600,
+    primary700: tokens.colors.primary700,
+    primary800: tokens.colors.primary800,
+
+    shadow: tokens.colors.shadow,
+    blue: tokens.colors.blue,
+
+    pink200: tokens.colors.pink200,
+    pink400: tokens.colors.pink400,
+    pink800: tokens.colors.pink800,
+
+    orange200: tokens.colors.orange200,
+    orange400: tokens.colors.orange400,
+    orange800: tokens.colors.orange800,
+
+    blue200: tokens.colors.blue200,
+    blue400: tokens.colors.blue400,
+    blue800: tokens.colors.blue800,
   },
   space: tokens.spacing,
   borderRadius: tokens.radius,

--- a/packages/theme/src/themes/index.ts
+++ b/packages/theme/src/themes/index.ts
@@ -2,4 +2,4 @@ import { vars } from './themes.css';
 
 export * from './themes.css';
 export type { ThemeContract } from './contract';
-export type Vars = typeof vars;
+export type VarsType = typeof vars;

--- a/packages/theme/src/themes/light.ts
+++ b/packages/theme/src/themes/light.ts
@@ -3,9 +3,9 @@ import type { ThemeContract } from './contract';
 
 export const lightTheme: ThemeContract = {
   colors: {
-    primary: tokens.colors.green200,
-    primary400to200: tokens.colors.green400,
-    primaryHover: tokens.colors.green300,
+    primary: tokens.colors.green200, // TODO: 삭제 예정
+    primary400to200: tokens.colors.green400, // TODO: 삭제 예정
+    primaryHover: tokens.colors.green300, // TODO: 삭제 예정
 
     warning: tokens.colors.warning500,
 
@@ -35,6 +35,26 @@ export const lightTheme: ThemeContract = {
     grey100to700Hover: tokens.colors.grey200,
     grey950toPrimary: tokens.colors.grey950,
     grey1000to1000: tokens.colors.grey1000,
+
+    primary500: tokens.colors.primary500,
+    primary600: tokens.colors.primary600,
+    primary700: tokens.colors.primary700,
+    primary800: tokens.colors.primary800,
+
+    shadow: tokens.colors.shadow,
+    blue: tokens.colors.blue,
+
+    pink200: tokens.colors.pink200,
+    pink400: tokens.colors.pink400,
+    pink800: tokens.colors.pink800,
+
+    orange200: tokens.colors.orange200,
+    orange400: tokens.colors.orange400,
+    orange800: tokens.colors.orange800,
+
+    blue200: tokens.colors.blue200,
+    blue400: tokens.colors.blue400,
+    blue800: tokens.colors.blue800,
   },
   space: tokens.spacing,
   borderRadius: tokens.radius,

--- a/packages/theme/src/tokens/colors.ts
+++ b/packages/theme/src/tokens/colors.ts
@@ -1,12 +1,30 @@
 export const colors = {
-  green100: '#F1FFB5',
-  green200: '#E6FF79',
-  green300: '#D0F141',
-  green400: '#D2F634',
+  green100: '#F1FFB5', // TODO: 삭제 예정
+  green200: '#E6FF79', // TODO: 삭제 예정
+  green300: '#D0F141', // TODO: 삭제 예정
+  green400: '#D2F634', // TODO: 삭제 예정
+
+  primary500: '#7081F4',
+  primary600: '#5266EC',
+  primary700: '#3348D6',
+  primary800: '#2035BC',
 
   warning300: '#FF724E',
   warning500: '#FF3300',
+  shadow: 'rgba(74, 98, 139, 0.3)',
   blue: '#1662E3',
+
+  pink200: '#FFD6D6',
+  pink400: '#EAAEAE',
+  pink800: '#A63535',
+
+  orange200: '#FFEAD9',
+  orange400: '#E09366',
+  orange800: '#903F28',
+
+  blue200: '#CDDFFF',
+  blue400: '#7698E2',
+  blue800: '#153C66',
 
   grey0: '#FFFFFF',
   grey25: '#F7F9FB',

--- a/packages/theme/src/tokens/index.ts
+++ b/packages/theme/src/tokens/index.ts
@@ -15,4 +15,8 @@ export const tokens = {
   typography,
 } as const;
 
-export type Tokens = typeof tokens;
+export type TypographyType = typeof typography;
+export type ColorsType = typeof colors;
+export type RadiusType = typeof radius;
+export type SpacingType = typeof spacing;
+export type TokensType = typeof tokens;


### PR DESCRIPTION
## 관련 이슈
close: #55 

## 변경 사항

추가된 색상을 업데이트하고, type을 export 했어요.

## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 테마 색상 팔레트 확장
		- 다양한 색상 음영 추가 (primary, pink, orange, blue)
		- 새로운 그림자(shadow) 색상 도입

- **개선 사항**
	- 기존 색상 토큰에 대한 타입 정의 세분화
	- 향후 삭제 예정인 색상에 대한 명시적 표기

- **기타**
	- 테마 계약(ThemeContract)의 색상 옵션 다양화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->