### PR TITLE
[Feat] Badge 컴포넌트 구현

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Icon, Toast, Text } from '@repo/ui';
+import { Icon, Toast, Text, Badge } from '@repo/ui';
 import { overlay } from 'overlay-kit';
 
 export default function Home() {
@@ -39,6 +39,23 @@ export default function Home() {
       <Text.H1 color="grey950" fontSize={28} fontWeight="semibold">
         hihi
       </Text.H1>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <Badge size="medium" variant="neautral" shape="round">
+          X Premium 계정 전용
+        </Badge>
+        <Badge size="medium" variant="pink" shape="square">
+          전체 적용
+        </Badge>
+        <Badge size="medium" variant="primary" shape="round">
+          X Premium 계정 전용
+        </Badge>
+        <Badge size="medium" variant="blue" shape="square">
+          개별 적용
+        </Badge>
+        <Badge size="large" variant="neautral" shape="square">
+          요약
+        </Badge>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
         hihi
       </Text.H1>
       <div style={{ display: 'flex', gap: '8px' }}>
-        <Badge size="medium" variant="neautral" shape="round">
+        <Badge size="medium" variant="neutral" shape="round">
           X Premium 계정 전용
         </Badge>
         <Badge size="medium" variant="primary" shape="round">
@@ -52,7 +52,7 @@ export default function Home() {
         <Badge size="medium" variant="blue" shape="square">
           개별 적용
         </Badge>
-        <Badge size="large" variant="neautral" shape="square">
+        <Badge size="large" variant="neutral" shape="square">
           요약
         </Badge>
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -43,11 +43,11 @@ export default function Home() {
         <Badge size="medium" variant="neautral" shape="round">
           X Premium 계정 전용
         </Badge>
-        <Badge size="medium" variant="pink" shape="square">
-          전체 적용
-        </Badge>
         <Badge size="medium" variant="primary" shape="round">
           X Premium 계정 전용
+        </Badge>
+        <Badge size="medium" variant="pink" shape="square">
+          전체 적용
         </Badge>
         <Badge size="medium" variant="blue" shape="square">
           개별 적용

--- a/packages/ui/src/components/Badge/Badge.css.ts
+++ b/packages/ui/src/components/Badge/Badge.css.ts
@@ -7,6 +7,7 @@ export const badge = recipe({
     alignItems: 'center',
     justifyContent: 'center',
     whiteSpace: 'nowrap',
+    height: 'fit-content',
   },
 
   variants: {
@@ -17,7 +18,7 @@ export const badge = recipe({
         lineHeight: '150%',
       },
       large: {
-        fontSize: vars.typography.fontSize[16],
+        fontSize: vars.typography.fontSize[20],
         fontWeight: vars.typography.fontWeight.semibold,
         lineHeight: '150%',
       },
@@ -42,13 +43,26 @@ export const badge = recipe({
     },
     shape: {
       round: {
-        padding: '4px 10px',
         borderRadius: 100,
       },
       square: {
-        padding: '2px 6px',
         borderRadius: '4px',
       },
     },
   },
+
+  compoundVariants: [
+    {
+      variants: { shape: 'round', size: 'medium' },
+      style: { padding: '4px 10px' },
+    },
+    {
+      variants: { shape: 'square', size: 'medium' },
+      style: { padding: '2px 6px' },
+    },
+    {
+      variants: { shape: 'square', size: 'large' },
+      style: { padding: '4px 8px' },
+    },
+  ],
 });

--- a/packages/ui/src/components/Badge/Badge.css.ts
+++ b/packages/ui/src/components/Badge/Badge.css.ts
@@ -24,7 +24,7 @@ export const badge = recipe({
       },
     },
     variant: {
-      neautral: {
+      neutral: {
         backgroundColor: vars.colors.grey50,
         color: vars.colors.grey600,
       },

--- a/packages/ui/src/components/Badge/Badge.css.ts
+++ b/packages/ui/src/components/Badge/Badge.css.ts
@@ -1,0 +1,54 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@repo/theme';
+
+export const badge = recipe({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    whiteSpace: 'nowrap',
+  },
+
+  variants: {
+    size: {
+      medium: {
+        fontSize: vars.typography.fontSize[14],
+        fontWeight: vars.typography.fontWeight.medium,
+        lineHeight: '150%',
+      },
+      large: {
+        fontSize: vars.typography.fontSize[16],
+        fontWeight: vars.typography.fontWeight.semibold,
+        lineHeight: '150%',
+      },
+    },
+    variant: {
+      neautral: {
+        backgroundColor: vars.colors.grey50,
+        color: vars.colors.grey600,
+      },
+      primary: {
+        backgroundColor: vars.colors.primary600,
+        color: vars.colors.grey,
+      },
+      pink: {
+        backgroundColor: vars.colors.pink200,
+        color: vars.colors.grey600,
+      },
+      blue: {
+        backgroundColor: vars.colors.blue200,
+        color: vars.colors.grey600,
+      },
+    },
+    shape: {
+      round: {
+        padding: '4px 10px',
+        borderRadius: 100,
+      },
+      square: {
+        padding: '2px 6px',
+        borderRadius: '4px',
+      },
+    },
+  },
+});

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -2,12 +2,36 @@ import { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import * as styles from './Badge.css';
 
+export type BadgeSize = 'medium' | 'large';
+export type BadgeVariant = 'neautral' | 'primary' | 'pink' | 'blue';
+export type BadgeShape = 'round' | 'square';
+
 type BadgeCombination =
-  | { size: 'medium'; variant: 'neautral'; shape: 'round' }
-  | { size: 'medium'; variant: 'pink'; shape: 'square' }
-  | { size: 'medium'; variant: 'primary'; shape: 'round' }
-  | { size: 'medium'; variant: 'blue'; shape: 'square' }
-  | { size: 'large'; variant: 'neautral'; shape: 'square' };
+  | {
+      size: Extract<BadgeSize, 'medium'>;
+      variant: Extract<BadgeVariant, 'neautral'>;
+      shape: Extract<BadgeShape, 'round'>;
+    }
+  | {
+      size: Extract<BadgeSize, 'medium'>;
+      variant: Extract<BadgeVariant, 'pink'>;
+      shape: Extract<BadgeShape, 'square'>;
+    }
+  | {
+      size: Extract<BadgeSize, 'medium'>;
+      variant: Extract<BadgeVariant, 'primary'>;
+      shape: Extract<BadgeShape, 'round'>;
+    }
+  | {
+      size: Extract<BadgeSize, 'medium'>;
+      variant: Extract<BadgeVariant, 'blue'>;
+      shape: Extract<BadgeShape, 'square'>;
+    }
+  | {
+      size: Extract<BadgeSize, 'large'>;
+      variant: Extract<BadgeVariant, 'neautral'>;
+      shape: Extract<BadgeShape, 'square'>;
+    };
 
 export type BadgeProps = HTMLAttributes<HTMLSpanElement> &
   BadgeCombination & {

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import * as styles from './Badge.css';
 
 export type BadgeSize = 'medium' | 'large';
@@ -35,7 +35,7 @@ type BadgeCombination =
 
 export type BadgeProps = HTMLAttributes<HTMLSpanElement> &
   BadgeCombination & {
-    children: React.ReactNode;
+    children: ReactNode;
   };
 
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,0 +1,29 @@
+import { forwardRef } from 'react';
+import type { HTMLAttributes } from 'react';
+import * as styles from './Badge.css';
+
+type BadgeCombination =
+  | { size: 'medium'; variant: 'neautral'; shape: 'round' }
+  | { size: 'medium'; variant: 'pink'; shape: 'square' }
+  | { size: 'medium'; variant: 'primary'; shape: 'round' }
+  | { size: 'medium'; variant: 'blue'; shape: 'square' }
+  | { size: 'large'; variant: 'neautral'; shape: 'square' };
+
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> &
+  BadgeCombination & {
+    children: React.ReactNode;
+  };
+
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ size, variant, shape, children, className = '', ...props }, ref) => (
+    <span
+      ref={ref}
+      className={`${styles.badge({ size, variant, shape })} ${className}`}
+      {...props}
+    >
+      {children}
+    </span>
+  )
+);
+
+Badge.displayName = 'Badge';

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -3,13 +3,13 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import * as styles from './Badge.css';
 
 export type BadgeSize = 'medium' | 'large';
-export type BadgeVariant = 'neautral' | 'primary' | 'pink' | 'blue';
+export type BadgeVariant = 'neutral' | 'primary' | 'pink' | 'blue';
 export type BadgeShape = 'round' | 'square';
 
 type BadgeCombination =
   | {
       size: Extract<BadgeSize, 'medium'>;
-      variant: Extract<BadgeVariant, 'neautral'>;
+      variant: Extract<BadgeVariant, 'neutral'>;
       shape: Extract<BadgeShape, 'round'>;
     }
   | {
@@ -29,7 +29,7 @@ type BadgeCombination =
     }
   | {
       size: Extract<BadgeSize, 'large'>;
-      variant: Extract<BadgeVariant, 'neautral'>;
+      variant: Extract<BadgeVariant, 'neutral'>;
       shape: Extract<BadgeShape, 'square'>;
     };
 

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -6,3 +6,5 @@ export { Toast } from './Toast';
 export type { ToastProps, ToastType, ToastIconProps } from './Toast';
 export { Text } from './Text/Text.subComponents';
 export type { AllowedTags, TextProps } from './Text/Text';
+export { Badge } from './Badge/Badge';
+export type { BadgeProps } from './Badge/Badge';


### PR DESCRIPTION
## 관련 이슈

#39 

## 변경 사항

디자이너 분들의 요구사항대로 뱃지의 종류를 제한하여 구현했어요. 

<img width="606" alt="image" src="https://github.com/user-attachments/assets/1ed256b8-c151-41c7-b317-713977715723" />

<img width="596" alt="image" src="https://github.com/user-attachments/assets/aa3aa066-7480-4b44-9dd7-d9a45f75b254" />


## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 다양한 크기, 변형 및 모양의 Badge 컴포넌트 추가
	- 계정 유형 및 상태를 시각적으로 표시하는 Badge 구현

- **스타일**
	- Badge 컴포넌트에 대한 새로운 CSS 모듈 도입
	- 중립, 기본, 분홍, 파란색 등 다양한 시각적 변형 지원

- **개선 사항**
	- UI 라이브러리에 Badge 컴포넌트 통합
	- 유연하고 맞춤 설정 가능한 Badge 디자인 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->