### PR TITLE
[Feat] Label 컴포넌트 구현

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Icon, Toast, Text, Badge, Checkbox } from '@repo/ui';
+import { Icon, Toast, Text, Badge, Checkbox, Label } from '@repo/ui';
 import { overlay } from 'overlay-kit';
 
 export default function Home() {
@@ -60,6 +60,11 @@ export default function Home() {
       <Checkbox label="체크박스" />
       <Checkbox label="체크박스" disabled checked />
       <Checkbox label="체크박스" disabled />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <Label variant="default">어떤 글을 생성할까요?</Label>
+        <Label variant="required">어떤 글을 생성할까요?</Label>
+        <Label variant="optional">어떤 글을 생성할까요?</Label>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/Label/Label.css.ts
+++ b/packages/ui/src/components/Label/Label.css.ts
@@ -1,0 +1,17 @@
+import { vars } from '@repo/theme';
+import { style } from '@vanilla-extract/css';
+
+export const labelStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: vars.typography.fontSize[20],
+  fontWeight: vars.typography.fontWeight.semibold,
+});
+
+export const requiredStyle = style({
+  gap: vars.space[4],
+});
+
+export const optionalStyle = style({
+  gap: vars.space[8],
+});

--- a/packages/ui/src/components/Label/Label.tsx
+++ b/packages/ui/src/components/Label/Label.tsx
@@ -1,0 +1,47 @@
+import { forwardRef, LabelHTMLAttributes } from 'react';
+import { Text } from '../Text/Text';
+import { labelStyle, requiredStyle, optionalStyle } from './Label.css';
+
+export type LabelVariant = 'default' | 'required' | 'optional';
+
+export type LabelProps = LabelHTMLAttributes<HTMLLabelElement> & {
+  variant?: LabelVariant;
+};
+
+const LABEL_CLASS = {
+  default: undefined,
+  required: requiredStyle,
+  optional: optionalStyle,
+} as const;
+
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ children, variant = 'default', className, ...props }, ref) => {
+    return (
+      <label
+        ref={ref}
+        className={`${labelStyle} ${LABEL_CLASS[variant]} ${className}`}
+        aria-required={variant === 'required'}
+        {...props}
+      >
+        {children}
+        {variant === 'required' && (
+          <Text
+            as="span"
+            fontSize={20}
+            fontWeight="semibold"
+            color="primary600"
+          >
+            *
+          </Text>
+        )}
+        {variant === 'optional' && (
+          <Text as="span" fontSize={16} fontWeight="semibold" color="grey300">
+            선택
+          </Text>
+        )}
+      </label>
+    );
+  }
+);
+
+Label.displayName = 'Label';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -10,3 +10,5 @@ export { Badge } from './Badge/Badge';
 export type { BadgeProps } from './Badge/Badge';
 export { Checkbox } from './Checkbox/Checkbox';
 export type { CheckboxProps } from './Checkbox/Checkbox';
+export { Label } from './Label/Label';
+export type { LabelProps, LabelVariant } from './Label/Label';


### PR DESCRIPTION
## 관련 이슈

#39 

## 변경 사항
<img width="470" alt="image" src="https://github.com/user-attachments/assets/2ad4bb5f-d6bc-4755-adc8-aed6c5fbee99" />
<img width="255" alt="image" src="https://github.com/user-attachments/assets/cf5da4da-8177-448f-b6ac-31274d720a28" />

요구사항에 따라 Label 컴포넌트를 구현했어요. 

## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- UI 컴포넌트 라이브러리에 `Label` 컴포넌트 추가
	- 다양한 레이블 변형 지원 (기본, 필수, 선택)
	- 접근성 및 테마 기반 스타일링 제공

- **스타일**
	- 레이블 컴포넌트에 대한 일관된 스타일 적용
	- 테마 변수를 활용한 유연한 디자인 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->