### PR TITLE
[Feat] 스켈레톤 컴포넌트

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   Breadcrumb,
   TextField,
   RadioCards,
+  Skeleton,
 } from '@repo/ui';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -258,6 +259,19 @@ export default function Home() {
             <RadioCards.Label>짧은 게시물</RadioCards.Label>
           </RadioCards.Item>
         </RadioCards>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '0.8rem',
+          margin: '2rem',
+          minWidth: '700px',
+        }}
+      >
+        <Skeleton width="30rem" height="2rem" radius={16} />
+        <Skeleton width="15rem" height="15rem" radius={4} />
+        <Skeleton width="15rem" height="15rem" />
       </div>
     </div>
   );

--- a/packages/ui/src/components/Skeleton/Skeleton.css.ts
+++ b/packages/ui/src/components/Skeleton/Skeleton.css.ts
@@ -1,0 +1,41 @@
+import { createVar, style, keyframes } from '@vanilla-extract/css';
+
+export const widthVar = createVar();
+export const heightVar = createVar();
+export const radiusVar = createVar();
+
+const shimmer = keyframes({
+  '0%': {
+    left: '-150%',
+  },
+  '80%': {
+    left: '150%',
+  },
+  '100%': {
+    left: '150%',
+  },
+});
+
+export const skeletonStyle = style({
+  borderRadius: radiusVar,
+  width: widthVar,
+  height: heightVar,
+
+  backgroundColor: '#EFEFF7',
+  position: 'relative',
+  overflow: 'hidden',
+
+  '::after': {
+    content: '',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: '-150%',
+    width: '70%',
+    height: '100%',
+    background:
+      'linear-gradient(to right, transparent 0%, rgba(255, 255, 255, 0.6) 30%, rgba(255, 255, 255, 0.6)70%,transparent 100%)',
+    animation: `${shimmer} 1.5s infinite`,
+    transform: 'skewY(0deg)',
+  },
+});

--- a/packages/ui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton/Skeleton.tsx
@@ -42,3 +42,5 @@ export function Skeleton({
     />
   );
 }
+
+Skeleton.displayName = 'Skeleton';

--- a/packages/ui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton/Skeleton.tsx
@@ -1,11 +1,12 @@
-import { tokens } from '@repo/theme';
+import { RadiusType } from '@repo/theme';
 import { heightVar, radiusVar, skeletonStyle, widthVar } from './Skeleton.css';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { CSSProperties } from '@vanilla-extract/css';
 
 export type SkeletonProps = {
-  width?: string;
-  height?: string;
-  radius?: keyof typeof tokens.spacing;
+  width?: CSSProperties['width'];
+  height?: CSSProperties['height'];
+  radius?: keyof RadiusType;
 };
 
 /**
@@ -14,7 +15,7 @@ export type SkeletonProps = {
  * @param {SkeletonProps} props - 스켈레톤 컴포넌트의 속성
  * @param {string} [props.width='100%'] - 스켈레톤의 너비
  * @param {string} [props.height='100%'] - 스켈레톤의 높이
- * @param {keyof typeof tokens.spacing} [props.radius] - 스켈레톤의 테두리 반경
+ * @param {keyof RadiusType} [props.radius] - 스켈레톤의 테두리 반경
  *
  *
  * @example
@@ -34,9 +35,9 @@ export function Skeleton({
       className={skeletonStyle}
       style={{
         ...assignInlineVars({
-          [widthVar]: width,
-          [heightVar]: height,
-          [radiusVar]: radiusValue,
+          [widthVar]: String(width),
+          [heightVar]: String(height),
+          [radiusVar]: String(radiusValue),
         }),
       }}
     />

--- a/packages/ui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,44 @@
+import { tokens } from '@repo/theme';
+import { heightVar, radiusVar, skeletonStyle, widthVar } from './Skeleton.css';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+export type SkeletonProps = {
+  width?: string;
+  height?: string;
+  radius?: keyof typeof tokens.spacing;
+};
+
+/**
+ *
+ * @component
+ * @param {SkeletonProps} props - 스켈레톤 컴포넌트의 속성
+ * @param {string} [props.width='100%'] - 스켈레톤의 너비
+ * @param {string} [props.height='100%'] - 스켈레톤의 높이
+ * @param {keyof typeof tokens.spacing} [props.radius] - 스켈레톤의 테두리 반경
+ *
+ *
+ * @example
+ * ```tsx
+ * <Skeleton width="32rem" height="16em" radius={16} />
+ * ```
+ */
+export function Skeleton({
+  width = '100%',
+  height = '100%',
+  radius,
+}: SkeletonProps) {
+  const radiusValue = radius ? `${radius}rem` : '100%';
+
+  return (
+    <div
+      className={skeletonStyle}
+      style={{
+        ...assignInlineVars({
+          [widthVar]: width,
+          [heightVar]: height,
+          [radiusVar]: radiusValue,
+        }),
+      }}
+    />
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -39,3 +39,5 @@ export type {
   RadioCardsDescriptionProps,
   RadioCardsBadgeProps,
 } from './RadioCards/RadioCards';
+export { Skeleton } from './Skeleton/Skeleton';
+export type { SkeletonProps } from './Skeleton/Skeleton';


### PR DESCRIPTION
## 관련 이슈
#39 

## 변경 사항
스켈레톤 컴포넌트 추가했습니다!
lottie 파일이나 다른 라이브러리를 활용하는 것보다 css로 구현하는 것이 가장 효율적인 방식이라 생각해 css로 구현해 보았어요.
width, height, radius prop을 내려 주어 원, 정사각형, 직사각형 모양의 스켈레톤 UI를 사용할 수 있도록 했습니다!
<img width="645" alt="image" src="https://github.com/user-attachments/assets/a95d0b81-310a-43f1-8f97-a60a77f17904" />


## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 로딩 상태를 나타내는 스켈레톤(Skeleton) 컴포넌트 추가
	- 페이지 로딩 중 사용자 경험 개선을 위한 동적 플레이스홀더 효과 구현

- **스타일**
	- 반짝이는 애니메이션 효과를 가진 스켈레톤 컴포넌트 스타일 도입
	- 너비, 높이, 테두리 반경 등 유연한 스타일링 옵션 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->