### PR TITLE
[Refactor] Spinner 컴포넌트 css 방식으로 변경

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,6 +13,7 @@ import { TextField } from '@repo/ui/TextField';
 import { RadioCards } from '@repo/ui/RadioCards';
 import { Skeleton } from '@repo/ui/Skeleton';
 import { Modal } from '@repo/ui/Modal';
+import { Spinner } from '@repo/ui/Spinner';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { overlay } from 'overlay-kit';
@@ -28,12 +29,12 @@ const LottieAnimation = dynamic(
   }
 );
 
-const Spinner = dynamic(
-  () => import('@repo/ui/Spinner').then((mod) => mod.Spinner),
-  {
-    ssr: false,
-  }
-);
+// const Spinner = dynamic(
+//   () => import('@repo/ui/Spinner').then((mod) => mod.Spinner),
+//   {
+//     ssr: false,
+//   }
+// );
 
 export default function Home() {
   const { register, handleSubmit } = useForm<FormValues>({
@@ -213,7 +214,7 @@ export default function Home() {
         </div>
       </form>
       <LottieAnimation
-        animationData="loadingBlack"
+        animationData="checkBlack"
         width="2.4rem"
         height="2.4rem"
       />
@@ -269,8 +270,10 @@ export default function Home() {
           backgroundColor: 'grey',
         }}
       >
-        <Spinner color="black" />
-        <Spinner color="white" />
+        <Spinner color="black" size="md" />
+        <Spinner color="black" size="lg" />
+        <Spinner color="white" size="md" />
+        <Spinner color="white" size="lg" />
       </div>
       <div style={{ margin: '2rem' }}>
         <RadioCards defaultValue="1" columns={2}>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -134,16 +134,30 @@ export default function Home() {
         >
           생성하기
         </Button>
+        <Button
+          size="large"
+          variant="primary"
+          leftAddon={<Icon name="twinkle" />}
+          isLoading
+        >
+          생성하기
+        </Button>
         <Button size="small" variant="neutral">
           다음
         </Button>
         <Button size="small" variant="neutral" disabled>
           다음
         </Button>
-        <Button size="large" variant="terminal">
+        <Button size="small" variant="neutral" isLoading>
+          다음
+        </Button>
+        <Button size="large" variant="text">
           이전
         </Button>
-        <Button size="small" variant="terminal">
+        <Button size="small" variant="text">
+          이전
+        </Button>
+        <Button size="small" variant="text" isLoading>
           이전
         </Button>
       </div>
@@ -270,10 +284,10 @@ export default function Home() {
           backgroundColor: 'grey',
         }}
       >
-        <Spinner color="black" size="md" />
-        <Spinner color="black" size="lg" />
-        <Spinner color="white" size="md" />
-        <Spinner color="white" size="lg" />
+        <Spinner color="black" size="small" />
+        <Spinner color="black" size="large" />
+        <Spinner color="white" size="small" />
+        <Spinner color="white" size="large" />
       </div>
       <div style={{ margin: '2rem' }}>
         <RadioCards defaultValue="1" columns={2}>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,6 @@
       "import": "./dist/index.js"
     },
     "./LottieAnimation": "./dist/components/LottieAnimation/LottieAnimation.js",
-    "./Spinner": "./dist/components/Spinner/Spinner.js",
     "./provider": {
       "types": "./dist/provider/index.d.ts",
       "import": "./dist/provider/index.js"
@@ -25,6 +24,10 @@
     "./IconButton": {
       "types": "./dist/components/IconButton/index.d.ts",
       "import": "./dist/components/IconButton/index.js"
+    },
+    "./Spinner": {
+      "types": "./dist/components/Spinner/index.d.ts",
+      "import": "./dist/components/Spinner/index.js"
     },
     "./Spacing": {
       "types": "./dist/components/Spacing/index.d.ts",

--- a/packages/ui/src/components/Button/Button.css.ts
+++ b/packages/ui/src/components/Button/Button.css.ts
@@ -9,6 +9,8 @@ export const buttonRecipe = recipe({
     justifyContent: 'center',
     whiteSpace: 'nowrap',
     height: 'fit-content',
+    lineHeight: '150%',
+    textAlign: 'center',
     border: 'none',
     cursor: 'pointer',
     transition: 'background-color 0.2s ease, color 0.2s ease',
@@ -24,14 +26,14 @@ export const buttonRecipe = recipe({
     size: {
       large: {
         gap: '0.8rem',
-        padding: '1.6rem 2rem',
+        padding: '1.2rem 1.8rem',
         borderRadius: tokens.radius[12],
-        fontSize: tokens.typography.fontSize[22],
+        fontSize: tokens.typography.fontSize[20],
         fontWeight: tokens.typography.fontWeight.semibold,
       },
       small: {
         gap: '0.4rem',
-        padding: '1rem 2rem',
+        padding: '0.8rem 2rem',
         borderRadius: tokens.radius[8],
         fontSize: tokens.typography.fontSize[18],
         fontWeight: tokens.typography.fontWeight.semibold,
@@ -67,7 +69,7 @@ export const buttonRecipe = recipe({
           },
         },
       },
-      terminal: {
+      text: {
         backgroundColor: 'transparent',
         color: tokens.colors.grey1000,
         selectors: {
@@ -83,15 +85,38 @@ export const buttonRecipe = recipe({
         },
       },
     },
+
+    isLoading: {
+      true: {
+        cursor: 'not-allowed',
+        pointerEvents: 'none',
+      },
+      false: {},
+    },
   },
+
+  compoundVariants: [
+    {
+      variants: { size: 'large', isLoading: true },
+      style: {
+        padding: '0.7rem 5.45rem',
+      },
+    },
+    {
+      variants: { size: 'small', isLoading: true },
+      style: {
+        padding: '0.55rem 2rem',
+      },
+    },
+  ],
 });
 
 export type ButtonRecipeVariants = RecipeVariants<typeof buttonRecipe>;
 
 export const addonRootStyle = styleVariants({
   large: {
-    width: '2.4rem',
-    height: '2.4rem',
+    width: '2.0rem',
+    height: '2.0rem',
   },
   small: {
     width: '1.6rem',

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,8 +1,9 @@
 import { ComponentPropsWithoutRef, forwardRef, ReactElement } from 'react';
 import { addonRootStyle, buttonRecipe } from './Button.css';
+import { Spinner, SpinnerProps } from '../Spinner';
 
 export type ButtonSize = 'small' | 'large';
-export type ButtonVariant = 'primary' | 'neutral' | 'terminal';
+export type ButtonVariant = 'primary' | 'neutral' | 'text';
 
 export type ButtonProps = ComponentPropsWithoutRef<'button'> & {
   size: ButtonSize;
@@ -10,6 +11,12 @@ export type ButtonProps = ComponentPropsWithoutRef<'button'> & {
   isLoading?: boolean;
   leftAddon?: ReactElement;
   rightAddon?: ReactElement;
+};
+
+const SpinnerColor: Record<ButtonVariant, SpinnerProps['color']> = {
+  primary: 'white',
+  neutral: 'white',
+  text: 'black',
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -28,13 +35,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ) => (
     <button
       ref={ref}
-      className={`${buttonRecipe({ size, variant })} ${className}`}
+      className={`${buttonRecipe({ size, variant, isLoading })} ${className}`}
       {...rest}
     >
       {isLoading ? (
         <>
-          // TODO Spinner 컴포넌트 넣을 예정
-          <span>로딩</span>
+          <Spinner color={SpinnerColor[variant]} size={size} />
         </>
       ) : (
         <>

--- a/packages/ui/src/components/Modal/compounds/DoubleCTA/DoubleCTA.tsx
+++ b/packages/ui/src/components/Modal/compounds/DoubleCTA/DoubleCTA.tsx
@@ -17,7 +17,7 @@ export const DoubleCTA = forwardRef<HTMLDivElement, ModalDoubleCTAProps>(
     <div ref={ref} className={styles.doubleCta}>
       <Button
         size={cancelProps?.size ?? 'large'}
-        variant={cancelProps?.variant ?? 'terminal'}
+        variant={cancelProps?.variant ?? 'text'}
         className={styles.secondaryButtonStyle}
         {...cancelProps}
       />

--- a/packages/ui/src/components/Spinner/Spinner.css.ts
+++ b/packages/ui/src/components/Spinner/Spinner.css.ts
@@ -1,0 +1,78 @@
+import { tokens } from '@repo/theme';
+import { keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+const rotate = keyframes({
+  from: { transform: 'rotate(0deg)' },
+  to: { transform: 'rotate(360deg)' },
+});
+
+const dash = keyframes({
+  '0%': {
+    strokeDasharray: '17.6 45.2',
+  },
+  '60%': {
+    strokeDasharray: '5 57.8',
+  },
+  '100%': {
+    strokeDasharray: '17.6 45.2',
+  },
+});
+
+export const spinner = style({
+  width: '3.2rem',
+  height: '3.2rem',
+  padding: '0.4rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const spinnerRecipe = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  variants: {
+    size: {
+      md: {
+        width: '3.2rem',
+        height: '3.2rem',
+        padding: '0.4rem',
+      },
+      lg: {
+        width: '4.0rem',
+        height: '4.0rem',
+        padding: '0.5rem',
+      },
+    },
+  },
+});
+
+export const svg = style({
+  animation: `${rotate} 0.8s linear infinite`,
+  width: '100%',
+  height: '100%',
+});
+
+export const circleRecipe = recipe({
+  base: {
+    fill: 'none',
+    stroke: '#000',
+    strokeWidth: '2.5',
+    strokeLinecap: 'round',
+    strokeDasharray: '17.6 45.2',
+    animation: `${dash} 0.8s ease-in-out infinite`,
+  },
+  variants: {
+    color: {
+      black: {
+        stroke: `${tokens.colors.grey1000}`,
+      },
+      white: {
+        stroke: `${tokens.colors.grey0}`,
+      },
+    },
+  },
+});

--- a/packages/ui/src/components/Spinner/Spinner.css.ts
+++ b/packages/ui/src/components/Spinner/Spinner.css.ts
@@ -36,12 +36,12 @@ export const spinnerRecipe = recipe({
   },
   variants: {
     size: {
-      md: {
+      small: {
         width: '3.2rem',
         height: '3.2rem',
         padding: '0.4rem',
       },
-      lg: {
+      large: {
         width: '4.0rem',
         height: '4.0rem',
         padding: '0.5rem',

--- a/packages/ui/src/components/Spinner/Spinner.tsx
+++ b/packages/ui/src/components/Spinner/Spinner.tsx
@@ -1,41 +1,33 @@
-'use client';
-
 import { forwardRef } from 'react';
-import { lotties } from '../LottieAnimation/assets';
-import {
-  LottieAnimation,
-  LottieAnimationProps,
-} from '../LottieAnimation/LottieAnimation';
-
-type LottieType = keyof typeof lotties;
-
-type SpinnerColorType = 'black' | 'white';
-
-const SpinnerColor: Record<SpinnerColorType, LottieType> = {
-  black: 'loadingBlack',
-  white: 'loadingWhite',
-};
+import * as styles from './Spinner.css';
 
 export type SpinnerProps = {
-  color?: keyof typeof SpinnerColor;
-} & Omit<LottieAnimationProps, 'animationData'>;
+  color?: 'black' | 'white';
+  size?: 'md' | 'lg';
+};
 
 /**
  * @param {SpinnerProps} props - 스피너 속성
- * @property {SpinnerColor} [color='white'] - 스피너 색상 선택
- * @property {LottieAnimationProps} [otherProps] - LottieAnimation의 props
+ * @property {color} [color='white'] - 'black' | 'white' 스피너 색상
+ * @property {size} [size='md'] - 'md' | 'lg' 스피너 크기
  */
-export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
-  ({ color = 'white', width = '4rem', height = '4rem', ...rest }) => {
+export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
+  ({ color = 'white', size = 'md' }, ref) => {
     return (
-      <span>
-        <LottieAnimation
-          animationData={SpinnerColor[color]}
-          width={width}
-          height={height}
-          {...rest}
-        />
-      </span>
+      <div ref={ref} className={styles.spinnerRecipe({ size })}>
+        <svg
+          className={styles.svg}
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            className={styles.circleRecipe({ color })}
+            cx="12"
+            cy="12"
+            r="10"
+          />
+        </svg>
+      </div>
     );
   }
 );

--- a/packages/ui/src/components/Spinner/Spinner.tsx
+++ b/packages/ui/src/components/Spinner/Spinner.tsx
@@ -3,16 +3,16 @@ import * as styles from './Spinner.css';
 
 export type SpinnerProps = {
   color?: 'black' | 'white';
-  size?: 'md' | 'lg';
+  size?: 'small' | 'large';
 };
 
 /**
  * @param {SpinnerProps} props - 스피너 속성
  * @property {color} [color='white'] - 'black' | 'white' 스피너 색상
- * @property {size} [size='md'] - 'md' | 'lg' 스피너 크기
+ * @property {size} [size='small'] - 'small' | 'large' 스피너 크기
  */
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
-  ({ color = 'white', size = 'md' }, ref) => {
+  ({ color = 'white', size = 'small' }, ref) => {
     return (
       <div ref={ref} className={styles.spinnerRecipe({ size })}>
         <svg


### PR DESCRIPTION
## 관련 이슈
close #87
#69
## 변경 사항
성능을 위해 Spinner 컴포넌트를 기존의 lottie 애니메이션으로 사용하던 방식에서 css로 변경했습니다. 디자이너 분께 애니메이션 확인도 받았어요!
그리고 버튼의 isLoading 상태에도 스피너 추가해 뒀어요!
<img width="908" alt="image" src="https://github.com/user-attachments/assets/e0876ed4-e5e6-4cdc-91c3-179bb40d8eb4" />
<img width="228" alt="image" src="https://github.com/user-attachments/assets/b9bfbf85-fb70-4677-b98b-fad57c9054ab" />

## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 스피너 컴포넌트의 크기와 색상 옵션 추가
	- 버튼의 로딩 상태 표시 기능 개선

- **버그 수정**
	- 스피너 컴포넌트의 렌더링 방식 최적화

- **스타일 변경**
	- 버튼 변형 옵션 'terminal'에서 'text'로 변경
	- 버튼 및 스피너의 스타일 세부 조정

- **기타 개선**
	- 컴포넌트 타입 정의 및 가독성 향상
	- 로딩 상태 시각적 표현 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->