### PR TITLE
[Feat] ky, tanstack-query 설정, 뉴스 카테고리 api 연동

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@repo/theme": "workspace:^",
     "@repo/ui": "workspace:^",
+    "@tanstack/react-query": "^5.66.0",
     "@vanilla-extract/css": "^1.17.0",
     "motion": "^11.17.0",
     "next": "14.2.21",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,8 @@
     "@repo/ui": "workspace:^",
     "@tanstack/react-query": "^5.66.0",
     "@vanilla-extract/css": "^1.17.0",
+    "cookies-next": "^5.1.0",
+    "ky": "^1.7.4",
     "motion": "^11.17.0",
     "next": "14.2.21",
     "overlay-kit": "^1.4.1",

--- a/apps/web/src/app/create/Create.tsx
+++ b/apps/web/src/app/create/Create.tsx
@@ -26,12 +26,15 @@ import {
 import * as styles from './pageStyle.css';
 import { useModal } from '@repo/ui/hooks';
 import { useRouter } from 'next/navigation';
+import { useNewsCategoriesQuery } from '@web/store/query/useNewsCategoriesQuery';
+import { isNotNil } from '@repo/ui/utils';
 
 const REQUIRED_FIELDS = {
   TOPIC: 'topic',
 } as const;
 
 export default function Create() {
+  const { data: newsCategories } = useNewsCategoriesQuery();
   const modal = useModal();
   const router = useRouter();
   const { watch, control, handleSubmit } = useForm<CreateFormValues>({
@@ -39,7 +42,9 @@ export default function Create() {
       topic: '',
       purpose: 'INFORMATION',
       reference: 'NONE',
-      newsCategory: '투자', // TODO: 백엔드로부터 받는 데이터 타입으로 수정
+      newsCategory: isNotNil(newsCategories.data[0]?.category)
+        ? newsCategories.data[0].category
+        : undefined,
       imageUrls: [], // TODO: presigned url 받아서 첨부
       length: 'SHORT',
       content: '',
@@ -211,9 +216,14 @@ export default function Create() {
                 name="newsCategory"
                 control={control}
                 render={({ field: { value, onChange } }) => (
-                  <KeywordChipGroup onChange={onChange} defaultValue={value}>
-                    {['투자', '패션', '피트니스', '헬스케어']}
-                  </KeywordChipGroup>
+                  <KeywordChipGroup
+                    items={newsCategories.data.map((category) => ({
+                      key: category.category,
+                      label: category.name,
+                    }))}
+                    value={value}
+                    onChange={(value) => onChange(value)}
+                  />
                 )}
               />
             </section>

--- a/apps/web/src/app/create/Create.tsx
+++ b/apps/web/src/app/create/Create.tsx
@@ -8,6 +8,7 @@ import {
   Breadcrumb,
   Icon,
   Button,
+  Modal,
 } from '@repo/ui';
 import { ImageManager, MainBreadcrumbItem } from '@web/components/common';
 import { KeywordChipGroup } from './_components/KeywordChip/KeywordChipGroup';
@@ -23,8 +24,16 @@ import {
   LENGTH_OPTIONS,
 } from './constants';
 import * as styles from './pageStyle.css';
+import { useModal } from '@repo/ui/hooks';
+import { useRouter } from 'next/navigation';
+
+const REQUIRED_FIELDS = {
+  TOPIC: 'topic',
+} as const;
 
 export default function Create() {
+  const modal = useModal();
+  const router = useRouter();
   const { watch, control, handleSubmit } = useForm<CreateFormValues>({
     defaultValues: {
       topic: '',
@@ -38,7 +47,7 @@ export default function Create() {
     mode: 'onChange',
   });
 
-  const topic = watch('topic');
+  const topic = watch(REQUIRED_FIELDS.TOPIC);
   const reference = watch('reference');
 
   const onSubmit = (data: CreateFormValues) => {
@@ -60,11 +69,27 @@ export default function Create() {
 
     const requestData = {
       ...data,
-      newsCategory: data.reference === 'NEWS' ? data.newsCategory : null,
-      imageUrls: data.reference === 'IMAGE' ? presignedUrls : null,
+      newsCategory:
+        data.reference === REFERENCE_TYPE.NEWS ? data.newsCategory : null,
+      imageUrls: data.reference === REFERENCE_TYPE.IMAGE ? presignedUrls : null,
     };
 
     console.log('폼 데이터:', requestData);
+  };
+
+  const handleHomeBreadcrumbClick = () => {
+    modal.confirm({
+      title: '정말 나가시겠어요?',
+      description: '이 페이지를 나가면\n작성한 내용은 저장되지 않아요',
+      icon: <Modal.Icon name="notice" color="warning500" />,
+      confirmButton: '나가기',
+      cancelButton: '취소',
+      confirmButtonProps: {
+        onClick: () => {
+          router.push('/');
+        },
+      },
+    });
   };
 
   const isSubmitDisabled = isEmptyStringOrNil(topic);
@@ -74,7 +99,14 @@ export default function Create() {
       <div className={styles.headerStyle}>
         <Breadcrumb>
           <Breadcrumb.Item>
-            <MainBreadcrumbItem href="/create" />
+            <MainBreadcrumbItem
+              href="/"
+              onClick={
+                !isEmptyStringOrNil(topic)
+                  ? handleHomeBreadcrumbClick
+                  : undefined
+              }
+            />
           </Breadcrumb.Item>
         </Breadcrumb>
         <Button

--- a/apps/web/src/app/create/_components/KeywordChip/KeywordChipGroup.tsx
+++ b/apps/web/src/app/create/_components/KeywordChip/KeywordChipGroup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { KeyboardEvent, ReactNode, useCallback, useState } from 'react';
+import { KeyboardEvent, useCallback, useState } from 'react';
 import { KeywordChip } from './KeywordChip';
 import { keywordChipGroupWrapper } from './KeywordChip.css';
 import { KeywordChipProvider } from './context';
@@ -11,22 +11,23 @@ const KEYBOARD_KEY = {
 } as const;
 
 type KeywordChipGroupProps = {
-  children: ReactNode[];
+  items: { key: string; label: string }[];
   onChange?: (value: string) => void;
+  value?: string;
   defaultValue?: string;
   disabled?: boolean;
   name?: string;
 };
 
 export const KeywordChipGroup = ({
-  children,
+  items,
   onChange,
-  defaultValue = '',
+  value: valueProp,
   disabled = false,
   name = 'keyword-group',
 }: KeywordChipGroupProps) => {
-  const [value, setValue] = useState(defaultValue);
   const [itemsRef] = useState<HTMLButtonElement[]>([]);
+  const [value, setValue] = useState(valueProp);
 
   const handleChange = useCallback(
     (newValue: string) => {
@@ -80,9 +81,9 @@ export const KeywordChipGroup = ({
         role="radiogroup"
         aria-label={name}
       >
-        {children.map((child) => (
-          <KeywordChip key={child?.toString()} value={child?.toString() ?? ''}>
-            {child}
+        {items.map(({ key, label }) => (
+          <KeywordChip key={key} value={key}>
+            {label}
           </KeywordChip>
         ))}
       </div>

--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -1,5 +1,15 @@
 import Create from './Create';
+import { newsCategoriesQueryOptions } from '@web/store/query/useNewsCategoriesQuery';
+import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
+import { getServerSideTokens } from '@web/features/server/serverSideTokens';
 
 export default function CreatePage() {
-  return <Create />;
+  const tokens = getServerSideTokens();
+  const serverFetchOptions = newsCategoriesQueryOptions(tokens);
+
+  return (
+    <ServerFetchBoundary fetchOptions={serverFetchOptions}>
+      <Create />
+    </ServerFetchBoundary>
+  );
 }

--- a/apps/web/src/components/common/MainBreadcrumbItem/MainBreadcrumbItem.tsx
+++ b/apps/web/src/components/common/MainBreadcrumbItem/MainBreadcrumbItem.tsx
@@ -4,13 +4,26 @@ import Link from 'next/link';
 
 type MainBreadcrumbItemProps = {
   href?: string;
+  onClick?: () => void;
 };
 
 export function MainBreadcrumbItem({
   href = '/create',
+  onClick,
 }: MainBreadcrumbItemProps) {
+  const handleClick = (event: React.MouseEvent) => {
+    if (onClick) {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
   return (
-    <Link href={href} className={styles.insteadTextWrapperStyle}>
+    <Link
+      href={href}
+      className={styles.insteadTextWrapperStyle}
+      onClick={handleClick}
+    >
       <Icon name="stack" size={32} color="grey900" />
       <span className={styles.insteadTextStyle}>Instead</span>
     </Link>

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ThemeProvider } from '@repo/ui/provider';
+import { QueryClientProvider } from '@web/store/query/QueryClientProvider';
 import { OverlayProvider } from 'overlay-kit';
 import { ReactNode } from 'react';
 
@@ -10,8 +11,10 @@ type ProvidersProps = {
 
 export function Providers({ children }: ProvidersProps) {
   return (
-    <ThemeProvider theme="light">
-      <OverlayProvider>{children}</OverlayProvider>
-    </ThemeProvider>
+    <QueryClientProvider>
+      <ThemeProvider theme="light">
+        <OverlayProvider>{children}</OverlayProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/web/src/features/server/api.ts
+++ b/apps/web/src/features/server/api.ts
@@ -1,0 +1,11 @@
+import ky from 'ky';
+
+const TIMEOUT = 10000;
+
+export const api = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_SERVER_BASE_URL,
+  timeout: TIMEOUT,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/apps/web/src/features/server/fetch.ts
+++ b/apps/web/src/features/server/fetch.ts
@@ -1,0 +1,66 @@
+import { ApiResponse, STATUS, Tokens } from './types';
+import { api } from './api';
+
+type FetchMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+type FetchOptions = {
+  method: FetchMethod;
+  json?: unknown;
+  searchParams?: Record<string, string>;
+};
+
+async function fetchWrapperWithTokenHandler<Data>(
+  uri: string,
+  options?: FetchOptions,
+  tokens?: Tokens
+): Promise<ApiResponse<Data>> {
+  try {
+    const response = await api[options?.method || 'get'](uri, {
+      json: options?.json,
+      searchParams: options?.searchParams,
+    }).json<ApiResponse<Data>>();
+    return response;
+  } catch (error) {
+    // error가 HTTPError인지 확인 후 처리
+    if (error instanceof Response) {
+      if (error.status === STATUS.UNAUTHORIZED && tokens) {
+        return await fetchWrapperWithTokenHandler<Data>(uri, options, tokens);
+      }
+    }
+
+    // 기타 예상치 못한 오류 처리
+    throw new Error(
+      `API 요청 실패: ${error instanceof Error ? error.message : '알 수 없는 오류'}`
+    );
+  }
+}
+
+export function POST<Data>(
+  uri: string,
+  body?: unknown,
+  tokens?: Tokens
+): Promise<ApiResponse<Data>> {
+  return fetchWrapperWithTokenHandler<Data>(
+    uri,
+    {
+      method: 'post',
+      json: body,
+    },
+    tokens
+  );
+}
+
+export function GET<Data>(
+  uri: string,
+  params?: Record<string, string>,
+  tokens?: Tokens
+): Promise<ApiResponse<Data>> {
+  return fetchWrapperWithTokenHandler<Data>(
+    uri,
+    {
+      method: 'get',
+      searchParams: params,
+    },
+    tokens
+  );
+}

--- a/apps/web/src/features/server/fetch.ts
+++ b/apps/web/src/features/server/fetch.ts
@@ -1,5 +1,6 @@
 import { ApiResponse, STATUS, Tokens } from './types';
 import { api } from './api';
+import { isNotNil } from '@repo/ui/utils';
 
 type FetchMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
 
@@ -14,8 +15,10 @@ async function fetchWrapperWithTokenHandler<Data>(
   options?: FetchOptions,
   tokens?: Tokens
 ): Promise<ApiResponse<Data>> {
+  const method = isNotNil(options?.method) ? options.method : 'get';
+
   try {
-    const response = await api[options?.method || 'get'](uri, {
+    const response = await api[method](uri, {
       json: options?.json,
       searchParams: options?.searchParams,
     }).json<ApiResponse<Data>>();

--- a/apps/web/src/features/server/fetch.ts
+++ b/apps/web/src/features/server/fetch.ts
@@ -64,3 +64,37 @@ export function GET<Data>(
     tokens
   );
 }
+
+export function PUT<Data>(
+  uri: string,
+  body?: unknown,
+  tokens?: Tokens
+): Promise<ApiResponse<Data>> {
+  return fetchWrapperWithTokenHandler<Data>(
+    uri,
+    {
+      method: 'put',
+      json: body,
+    },
+    tokens
+  );
+}
+
+export function DELETE<Data>(
+  uri: string,
+  tokens?: Tokens
+): Promise<ApiResponse<Data>> {
+  return fetchWrapperWithTokenHandler<Data>(uri, { method: 'delete' }, tokens);
+}
+
+export function PATCH<Data>(
+  uri: string,
+  body?: unknown,
+  tokens?: Tokens
+): Promise<ApiResponse<Data>> {
+  return fetchWrapperWithTokenHandler<Data>(
+    uri,
+    { method: 'patch', json: body },
+    tokens
+  );
+}

--- a/apps/web/src/features/server/index.ts
+++ b/apps/web/src/features/server/index.ts
@@ -1,0 +1,1 @@
+export { POST, GET } from './fetch';

--- a/apps/web/src/features/server/index.ts
+++ b/apps/web/src/features/server/index.ts
@@ -1,1 +1,1 @@
-export { POST, GET } from './fetch';
+export { POST, GET, PUT, DELETE, PATCH } from './fetch';

--- a/apps/web/src/features/server/serverSideTokens.ts
+++ b/apps/web/src/features/server/serverSideTokens.ts
@@ -1,0 +1,10 @@
+import { getCookie } from 'cookies-next';
+import { cookies } from 'next/headers';
+
+/**
+ * @description 서버에서 쿠키 가져오기
+ */
+export const getServerSideTokens = () => ({
+  accessToken: String(getCookie('accessToken', { cookies })) || '',
+  refreshToken: String(getCookie('refreshToken', { cookies })) || '',
+});

--- a/apps/web/src/features/server/types.ts
+++ b/apps/web/src/features/server/types.ts
@@ -1,0 +1,18 @@
+export interface ApiResponse<Data> {
+  status: number;
+  data: Data;
+  timeStamp: string;
+}
+
+export const STATUS = {
+  SUCCESS: 200,
+  UNKNOWN: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  DUPLICATE: 409,
+} as const;
+
+export type Status = (typeof STATUS)[keyof typeof STATUS];
+
+export type Tokens = { accessToken: string; refreshToken: string };

--- a/apps/web/src/store/query/QueryClientProvider.tsx
+++ b/apps/web/src/store/query/QueryClientProvider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { QueryClientProvider as _QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { getQueryClient } from './getQueryClient';
+
+export function QueryClientProvider({ children }: { children: ReactNode }) {
+  const queryClient = getQueryClient();
+
+  return (
+    <_QueryClientProvider client={queryClient}>{children}</_QueryClientProvider>
+  );
+}

--- a/apps/web/src/store/query/ServerFetchBoundary.tsx
+++ b/apps/web/src/store/query/ServerFetchBoundary.tsx
@@ -1,0 +1,32 @@
+import {
+  type FetchQueryOptions,
+  HydrationBoundary,
+  dehydrate,
+} from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { getQueryClient } from './getQueryClient';
+
+export type FetchOptions = Pick<FetchQueryOptions, 'queryKey' | 'queryFn'>;
+
+type Props = {
+  fetchOptions: FetchOptions[] | FetchOptions;
+  children: ReactNode | ReactNode[];
+};
+
+export async function ServerFetchBoundary({ fetchOptions, children }: Props) {
+  const queryClient = getQueryClient();
+
+  if (Array.isArray(fetchOptions)) {
+    for (const option of fetchOptions) {
+      await queryClient.fetchQuery(option);
+    }
+  } else {
+    await queryClient.fetchQuery(fetchOptions);
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      {children}
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/store/query/ServerFetchBoundary.tsx
+++ b/apps/web/src/store/query/ServerFetchBoundary.tsx
@@ -1,28 +1,42 @@
-import {
-  type FetchQueryOptions,
-  HydrationBoundary,
-  dehydrate,
-} from '@tanstack/react-query';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import type { FetchQueryOptions } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { getQueryClient } from './getQueryClient';
+import type { QueryKey } from '@tanstack/react-query';
 
-export type FetchOptions = Pick<FetchQueryOptions, 'queryKey' | 'queryFn'>;
+export type FetchOptions<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = Pick<
+  FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  'queryKey' | 'queryFn'
+>;
 
-type Props = {
-  fetchOptions: FetchOptions[] | FetchOptions;
+type Props<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = {
+  fetchOptions:
+    | FetchOptions<TQueryFnData, TError, TData, TQueryKey>[]
+    | FetchOptions<TQueryFnData, TError, TData, TQueryKey>;
   children: ReactNode | ReactNode[];
 };
 
-export async function ServerFetchBoundary({ fetchOptions, children }: Props) {
+export function ServerFetchBoundary<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>({ fetchOptions, children }: Props<TQueryFnData, TError, TData, TQueryKey>) {
   const queryClient = getQueryClient();
 
-  if (Array.isArray(fetchOptions)) {
-    for (const option of fetchOptions) {
-      await queryClient.fetchQuery(option);
-    }
-  } else {
-    await queryClient.fetchQuery(fetchOptions);
-  }
+  const options = Array.isArray(fetchOptions) ? fetchOptions : [fetchOptions];
+
+  options.forEach((option) => queryClient.fetchQuery(option));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/web/src/store/query/getQueryClient.ts
+++ b/apps/web/src/store/query/getQueryClient.ts
@@ -4,7 +4,7 @@ import {
   defaultShouldDehydrateQuery,
 } from '@tanstack/react-query';
 
-const DEFAULT_STALE_TIME = 10 * 60 * 1000;
+const DEFAULT_STALE_TIME = 60 * 1000;
 
 function makeQueryClient() {
   return new QueryClient({

--- a/apps/web/src/store/query/getQueryClient.ts
+++ b/apps/web/src/store/query/getQueryClient.ts
@@ -1,0 +1,33 @@
+import {
+  isServer,
+  QueryClient,
+  defaultShouldDehydrateQuery,
+} from '@tanstack/react-query';
+
+const DEFAULT_STALE_TIME = 10 * 60 * 1000;
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: DEFAULT_STALE_TIME,
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === 'pending',
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}

--- a/apps/web/src/store/query/useNewsCategoriesQuery.ts
+++ b/apps/web/src/store/query/useNewsCategoriesQuery.ts
@@ -1,0 +1,29 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { GET } from '@web/features/server/fetch';
+import { Tokens } from '@web/features/server/types';
+
+export interface NewsCategory {
+  /**
+   * 서버로 넘겨줄 카테고리명 (예: "INVESTING", "COOK")
+   */
+  category: string;
+  /**
+   * 화면에 표시될 카테고리명 (예: "투자", "요리")
+   */
+  name: string;
+}
+
+type NewsCategoriesQuery = NewsCategory[];
+
+export function newsCategoriesQueryOptions(tokens?: Tokens) {
+  return queryOptions({
+    queryKey: ['news', 'categories'],
+    queryFn: () =>
+      GET<NewsCategoriesQuery>(`news-categories`, undefined, tokens),
+    staleTime: 0,
+  });
+}
+
+export function useNewsCategoriesQuery() {
+  return useSuspenseQuery(newsCategoriesQueryOptions());
+}

--- a/packages/ui/src/hooks/useModal.tsx
+++ b/packages/ui/src/hooks/useModal.tsx
@@ -137,7 +137,14 @@ export function useModal() {
           onClose={close}
           onExited={unmount}
           cta={
-            <Modal.CTA onClick={close} {...options.alertButtonProps}>
+            <Modal.CTA
+              onClick={
+                isNotNil(options.alertButtonProps?.onClick)
+                  ? options.alertButtonProps.onClick
+                  : close
+              }
+              {...options.alertButtonProps}
+            >
               {alertButton}
             </Modal.CTA>
           }
@@ -213,12 +220,16 @@ export function useModal() {
             <Modal.DoubleCTA
               confirmProps={{
                 children: confirmButton,
-                onClick: close,
+                onClick: isNotNil(options.confirmButtonProps?.onClick)
+                  ? options.confirmButtonProps.onClick
+                  : close,
                 ...options.confirmButtonProps,
               }}
               cancelProps={{
                 children: cancelButton,
-                onClick: close,
+                onClick: isNotNil(options.cancelButtonProps?.onClick)
+                  ? options.cancelButtonProps.onClick
+                  : close,
                 ...options.cancelButtonProps,
               }}
             />

--- a/packages/ui/src/hooks/useModal.tsx
+++ b/packages/ui/src/hooks/useModal.tsx
@@ -131,6 +131,9 @@ type AsyncConfirmOptions = ConfirmOptions & {
 export function useModal() {
   const alert = useCallback(
     ({ alertButton = '확인', ...options }: AlertOptions) => {
+      const { onClick: alertOnClick, ...restAlertProps } =
+        options.alertButtonProps || {};
+
       return overlay.open(({ isOpen, close, unmount }) => (
         <Modal
           open={isOpen}
@@ -138,12 +141,13 @@ export function useModal() {
           onExited={unmount}
           cta={
             <Modal.CTA
-              onClick={
-                isNotNil(options.alertButtonProps?.onClick)
-                  ? options.alertButtonProps.onClick
-                  : close
-              }
-              {...options.alertButtonProps}
+              onClick={(e) => {
+                if (alertOnClick) {
+                  alertOnClick(e);
+                }
+                close();
+              }}
+              {...restAlertProps}
             >
               {alertButton}
             </Modal.CTA>
@@ -210,6 +214,11 @@ export function useModal() {
       cancelButton = '취소',
       ...options
     }: ConfirmOptions) => {
+      const { onClick: confirmOnClick, ...restConfirmProps } =
+        options.confirmButtonProps || {};
+      const { onClick: cancelOnClick, ...restCancelProps } =
+        options.cancelButtonProps || {};
+
       return overlay.open(({ isOpen, close, unmount }) => (
         <Modal
           open={isOpen}
@@ -220,17 +229,23 @@ export function useModal() {
             <Modal.DoubleCTA
               confirmProps={{
                 children: confirmButton,
-                onClick: isNotNil(options.confirmButtonProps?.onClick)
-                  ? options.confirmButtonProps.onClick
-                  : close,
-                ...options.confirmButtonProps,
+                onClick: (e) => {
+                  if (confirmOnClick) {
+                    confirmOnClick(e);
+                  }
+                  close();
+                },
+                ...restConfirmProps,
               }}
               cancelProps={{
                 children: cancelButton,
-                onClick: isNotNil(options.cancelButtonProps?.onClick)
-                  ? options.cancelButtonProps.onClick
-                  : close,
-                ...options.cancelButtonProps,
+                onClick: (e) => {
+                  if (cancelOnClick) {
+                    cancelOnClick(e);
+                  }
+                  close();
+                },
+                ...restCancelProps,
               }}
             />
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.17.0
         version: 1.17.0
+      cookies-next:
+        specifier: ^5.1.0
+        version: 5.1.0(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      ky:
+        specifier: ^1.7.4
+        version: 1.7.4
       motion:
         specifier: ^11.17.0
         version: 11.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -175,10 +181,10 @@ importers:
         version: 18.3.0
       '@vanilla-extract/esbuild-plugin':
         specifier: ^2.3.5
-        version: 2.3.13(@types/node@20.17.6)(esbuild@0.21.5)(terser@5.37.0)
+        version: 2.3.13(@types/node@20.17.12)(esbuild@0.21.5)(terser@5.37.0)
       '@vanilla-extract/next-plugin':
         specifier: ^2.4.8
-        version: 2.4.8(next@14.2.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
+        version: 2.4.8(@types/node@20.17.12)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
       esbuild:
         specifier: ^0.21.0
         version: 0.21.5
@@ -1908,6 +1914,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
+  cookies-next@5.1.0:
+    resolution: {integrity: sha512-9Ekne+q8hfziJtnT9c1yDUBqT0eDMGgPrfPl4bpR3xwQHLTd/8gbSf6+IEkP/pjGsDZt1TGbC6emYmFYRbIXwQ==}
+    peerDependencies:
+      next: '>=15.0.0'
+      react: '>= 16.8.0'
+
   core-js-compat@3.40.0:
     resolution: {integrity: sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==}
 
@@ -2703,6 +2719,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  ky@1.7.4:
+    resolution: {integrity: sha512-zYEr/gh7uLW2l4su11bmQ2M9xLgQLjyvx58UyNM/6nuqyWFHPX5ktMjvpev3F8QWdjSsHUpnWew4PBCswBNuMQ==}
+    engines: {node: '>=18'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -4940,11 +4960,80 @@ snapshots:
     dependencies:
       '@vanilla-extract/private': 1.0.6
 
+  '@vanilla-extract/esbuild-plugin@2.3.13(@types/node@20.17.12)(esbuild@0.21.5)(terser@5.37.0)':
+    dependencies:
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.12)(terser@5.37.0)
+    optionalDependencies:
+      esbuild: 0.21.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   '@vanilla-extract/esbuild-plugin@2.3.13(@types/node@20.17.6)(esbuild@0.21.5)(terser@5.37.0)':
     dependencies:
       '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)(terser@5.37.0)
     optionalDependencies:
       esbuild: 0.21.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  '@vanilla-extract/integration@7.1.12(@types/node@20.17.12)(terser@5.37.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
+      '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
+      '@vanilla-extract/css': 1.17.0
+      dedent: 1.5.3
+      esbuild: 0.21.5
+      eval: 0.1.8
+      find-up: 5.0.0
+      javascript-stringify: 2.1.0
+      mlly: 1.7.3
+      vite: 5.4.11(@types/node@20.17.12)(terser@5.37.0)
+      vite-node: 1.6.0(@types/node@20.17.12)(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  '@vanilla-extract/integration@7.1.12(@types/node@20.17.6)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
+      '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
+      '@vanilla-extract/css': 1.17.0
+      dedent: 1.5.3
+      esbuild: 0.21.5
+      eval: 0.1.8
+      find-up: 5.0.0
+      javascript-stringify: 2.1.0
+      mlly: 1.7.3
+      vite: 5.4.11(@types/node@20.17.6)(terser@5.37.0)
+      vite-node: 1.6.0(@types/node@20.17.6)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -4983,9 +5072,9 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/next-plugin@2.4.8(@types/node@20.17.6)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.97.1)':
+  '@vanilla-extract/next-plugin@2.4.8(@types/node@20.17.12)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.6)(webpack@5.97.1)
+      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.12)(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
       next: 14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -5000,9 +5089,9 @@ snapshots:
       - terser
       - webpack
 
-  '@vanilla-extract/next-plugin@2.4.8(next@14.2.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
+  '@vanilla-extract/next-plugin@2.4.8(@types/node@20.17.6)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.97.1)':
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.3.16(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
+      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.6)(webpack@5.97.1)
       next: 14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -5027,13 +5116,13 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.0
 
-  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.6)(webpack@5.97.1)':
+  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.12)(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)(terser@5.37.0)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.12)(terser@5.37.0)
       debug: 4.4.0
       loader-utils: 2.0.4
       picocolors: 1.1.1
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.21.5)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5046,13 +5135,13 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/webpack-plugin@2.3.16(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
+  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.6)(webpack@5.97.1)':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)(terser@5.37.0)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)
       debug: 4.4.0
       loader-utils: 2.0.4
       picocolors: 1.1.1
-      webpack: 5.97.1(esbuild@0.21.5)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5405,6 +5494,14 @@ snapshots:
   confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
+
+  cookies-next@5.1.0(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.0.2
+      next: 14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   core-js-compat@3.40.0:
     dependencies:
@@ -6348,6 +6445,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  ky@1.7.4: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -7185,6 +7284,42 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  vite-node@1.6.0(@types/node@20.17.12)(terser@5.37.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.11(@types/node@20.17.12)(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@1.6.0(@types/node@20.17.6):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.11(@types/node@20.17.6)(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@1.6.0(@types/node@20.17.6)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
@@ -7202,6 +7337,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite@5.4.11(@types/node@20.17.12)(terser@5.37.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.29.1
+    optionalDependencies:
+      '@types/node': 20.17.12
+      fsevents: 2.3.3
+      terser: 5.37.0
 
   vite@5.4.11(@types/node@20.17.6)(terser@5.37.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@repo/ui':
         specifier: workspace:^
         version: link:../../packages/ui
+      '@tanstack/react-query':
+        specifier: ^5.66.0
+        version: 5.66.0(react@18.3.1)
       '@vanilla-extract/css':
         specifier: ^1.17.0
         version: 1.17.0
@@ -172,10 +175,10 @@ importers:
         version: 18.3.0
       '@vanilla-extract/esbuild-plugin':
         specifier: ^2.3.5
-        version: 2.3.13(@types/node@20.17.12)(esbuild@0.21.5)(terser@5.37.0)
+        version: 2.3.13(@types/node@20.17.6)(esbuild@0.21.5)(terser@5.37.0)
       '@vanilla-extract/next-plugin':
         specifier: ^2.4.8
-        version: 2.4.8(@types/node@20.17.12)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
+        version: 2.4.8(next@14.2.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
       esbuild:
         specifier: ^0.21.0
         version: 0.21.5
@@ -1461,6 +1464,14 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@tanstack/query-core@5.66.0':
+    resolution: {integrity: sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==}
+
+  '@tanstack/react-query@5.66.0':
+    resolution: {integrity: sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -4776,6 +4787,13 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
+  '@tanstack/query-core@5.66.0': {}
+
+  '@tanstack/react-query@5.66.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.66.0
+      react: 18.3.1
+
   '@trysound/sax@0.2.0': {}
 
   '@types/eslint-scope@3.7.7':
@@ -4922,80 +4940,11 @@ snapshots:
     dependencies:
       '@vanilla-extract/private': 1.0.6
 
-  '@vanilla-extract/esbuild-plugin@2.3.13(@types/node@20.17.12)(esbuild@0.21.5)(terser@5.37.0)':
-    dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.12)(terser@5.37.0)
-    optionalDependencies:
-      esbuild: 0.21.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   '@vanilla-extract/esbuild-plugin@2.3.13(@types/node@20.17.6)(esbuild@0.21.5)(terser@5.37.0)':
     dependencies:
       '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)(terser@5.37.0)
     optionalDependencies:
       esbuild: 0.21.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  '@vanilla-extract/integration@7.1.12(@types/node@20.17.12)(terser@5.37.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-      '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
-      '@vanilla-extract/css': 1.17.0
-      dedent: 1.5.3
-      esbuild: 0.21.5
-      eval: 0.1.8
-      find-up: 5.0.0
-      javascript-stringify: 2.1.0
-      mlly: 1.7.3
-      vite: 5.4.11(@types/node@20.17.12)(terser@5.37.0)
-      vite-node: 1.6.0(@types/node@20.17.12)(terser@5.37.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  '@vanilla-extract/integration@7.1.12(@types/node@20.17.6)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-      '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
-      '@vanilla-extract/css': 1.17.0
-      dedent: 1.5.3
-      esbuild: 0.21.5
-      eval: 0.1.8
-      find-up: 5.0.0
-      javascript-stringify: 2.1.0
-      mlly: 1.7.3
-      vite: 5.4.11(@types/node@20.17.6)(terser@5.37.0)
-      vite-node: 1.6.0(@types/node@20.17.6)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5034,9 +4983,9 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/next-plugin@2.4.8(@types/node@20.17.12)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
+  '@vanilla-extract/next-plugin@2.4.8(@types/node@20.17.6)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.97.1)':
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.12)(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
+      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.6)(webpack@5.97.1)
       next: 14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -5051,9 +5000,9 @@ snapshots:
       - terser
       - webpack
 
-  '@vanilla-extract/next-plugin@2.4.8(@types/node@20.17.6)(next@14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.97.1)':
+  '@vanilla-extract/next-plugin@2.4.8(next@14.2.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.6)(webpack@5.97.1)
+      '@vanilla-extract/webpack-plugin': 2.3.16(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))
       next: 14.2.21(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -5078,13 +5027,13 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.0
 
-  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.12)(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
+  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.6)(webpack@5.97.1)':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.12)(terser@5.37.0)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)(terser@5.37.0)
       debug: 4.4.0
       loader-utils: 2.0.4
       picocolors: 1.1.1
-      webpack: 5.97.1(esbuild@0.21.5)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5097,13 +5046,13 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.6)(webpack@5.97.1)':
+  '@vanilla-extract/webpack-plugin@2.3.16(terser@5.37.0)(webpack@5.97.1(esbuild@0.21.5))':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.6)(terser@5.37.0)
       debug: 4.4.0
       loader-utils: 2.0.4
       picocolors: 1.1.1
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.21.5)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -7236,42 +7185,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  vite-node@1.6.0(@types/node@20.17.12)(terser@5.37.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.11(@types/node@20.17.12)(terser@5.37.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@1.6.0(@types/node@20.17.6):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.11(@types/node@20.17.6)(terser@5.37.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@1.6.0(@types/node@20.17.6)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
@@ -7289,16 +7202,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vite@5.4.11(@types/node@20.17.12)(terser@5.37.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.29.1
-    optionalDependencies:
-      '@types/node': 20.17.12
-      fsevents: 2.3.3
-      terser: 5.37.0
 
   vite@5.4.11(@types/node@20.17.6)(terser@5.37.0):
     dependencies:


### PR DESCRIPTION
## 관련 이슈

close: #96

## 변경 사항

변경 및 추가된 코드 양이 많고, @kongnayeon 님께서 가져다 쓰실 수 있도록 분할하여 PR을 올려요!

각 요청 method에 해당하는 함수(GET, POST, PUT, PATCH, DELETE)를 사용하면 돼요. 

그리고, 클라이언트 환경에서 사용하실 때는 token을 따로 넘기지 않고, 서버 환경에서의 fetching이 필요하실 때는 아래와 같이 `getServerSideTokens` 가 리턴하는 토큰을 QueryOptions에 주입하고, ServerFetchBoundary의 fetchOptions에 props로 넘겨 사용하시면 돼요.

```tsx

import Create from './Create';
import { newsCategoriesQueryOptions } from '@web/store/query/useNewsCategoriesQuery';
import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
import { getServerSideTokens } from '@web/features/server/serverSideTokens';

export default function CreatePage() {
  const tokens = getServerSideTokens();
  const serverFetchOptions = newsCategoriesQueryOptions(tokens);

  return (
    <ServerFetchBoundary fetchOptions={serverFetchOptions}>
      <Create />
    </ServerFetchBoundary>
  );
}


```

## 레퍼런스
