### PR TITLE
[Fix] 불필요 await 제거

### DIFF
--- a/apps/web/src/store/query/ServerFetchBoundary.tsx
+++ b/apps/web/src/store/query/ServerFetchBoundary.tsx
@@ -35,7 +35,7 @@ export async function ServerFetchBoundary<
 
   const options = Array.isArray(fetchOptions) ? fetchOptions : [fetchOptions];
 
-  await Promise.all(options.map((option) => queryClient.fetchQuery(option)));
+  Promise.all(options.map((option) => queryClient.fetchQuery(option)));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>


### PR DESCRIPTION
## 관련 이슈

close: #166 

## 변경 사항

사용처에서 useSuspenseQuery를 사용할 때, 이미 Promise를 throw하고 있어요.

따라서 ServerFetchBoundary에서 Promise.all을 await 할 필요가 없게 되어 await을 삭제합니다.


## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 백그라운드 데이터 요청 처리가 개선되어, 인터페이스가 요청 완료를 기다리지 않고 빠르게 렌더링됩니다.
	- 이 변경으로 불필요한 대기 시간이 줄어들어, 사용자 경험과 응답성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->