### PR TITLE
fix(apps/web): useSuspenseQueries로 폭포수 개선 및 Suspense boundary 래핑

### DIFF
--- a/apps/web/src/app/(home)/Home.tsx
+++ b/apps/web/src/app/(home)/Home.tsx
@@ -28,13 +28,14 @@ import { PersonalCard } from './[agentId]/_components/PersonalCard/PersonalCard'
 import { UploadContentCard } from './[agentId]/_components/UploadContentCard/UploadContentCard';
 import { ContentGroupCard } from './[agentId]/_components/ContentGroupCard/ContentGroupCard';
 import { Spacing } from '@repo/ui/Spacing';
-import { useGetAgentQuery } from '@web/store/query/useGetAgentQuery';
+import { getAgentQueryOptions } from '@web/store/query/useGetAgentQuery';
 import { useRouter } from 'next/navigation';
 import { Agent } from '@web/types';
-import { useGetUserQuery } from '@web/store/query/useGetUserQuery';
+import { getUserQueryOptions } from '@web/store/query/useGetUserQuery';
 import { useLogoutMutation } from '@web/store/mutation/useLogoutMutation';
 import { useModal, useToast } from '@repo/ui/hooks';
 import { Modal } from '@repo/ui/Modal';
+import { useSuspenseQueries } from '@tanstack/react-query';
 
 export default function Home() {
   const router = useRouter();
@@ -43,8 +44,11 @@ export default function Home() {
   const [scrollRef, isScrolled] = useScroll<HTMLDivElement>({
     threshold: 100,
   });
-  const { data: user } = useGetUserQuery();
-  const { data: agentData } = useGetAgentQuery();
+
+  const [{ data: user }, { data: agentData }] = useSuspenseQueries({
+    queries: [getUserQueryOptions(), getAgentQueryOptions()],
+  });
+
   const { mutate: logout } = useLogoutMutation();
 
   const handleLogoutClick = () => {

--- a/apps/web/src/app/(home)/[agentId]/Home.tsx
+++ b/apps/web/src/app/(home)/[agentId]/Home.tsx
@@ -28,18 +28,19 @@ import { PersonalCard } from './_components/PersonalCard/PersonalCard';
 import { UploadContentCard } from './_components/UploadContentCard/UploadContentCard';
 import { ContentGroupCard } from './_components/ContentGroupCard/ContentGroupCard';
 import { Spacing } from '@repo/ui/Spacing';
-import { useGetAgentDetailQuery } from '@web/store/query/useGetAgentDetailQuery';
-import { useGetAgentPostGroupsQuery } from '@web/store/query/useGetAgentPostGroupsQuery';
-import { useGetAgentQuery } from '@web/store/query/useGetAgentQuery';
-import { useGetAgentUploadReservedQuery } from '@web/store/query/useGetAgentUploadReserved';
+import { getAgentDetailQueryOptions } from '@web/store/query/useGetAgentDetailQuery';
+import { getAgentPostGroupsQueryOptions } from '@web/store/query/useGetAgentPostGroupsQuery';
+import { getAgentQueryOptions } from '@web/store/query/useGetAgentQuery';
+import { getAgentUploadReservedQueryOptions } from '@web/store/query/useGetAgentUploadReserved';
+import { getUserQueryOptions } from '@web/store/query/useGetUserQuery';
 import { HomePageProps } from './types';
 import { useRouter } from 'next/navigation';
 import { Agent, PostGroupId } from '@web/types';
 import { useModal } from '@repo/ui/hooks';
 import { Modal } from '@repo/ui/Modal';
 import { useDeletePostGroupMutation } from '@web/store/mutation/useDeletePostGroupMutation';
-import { useGetUserQuery } from '@web/store/query/useGetUserQuery';
 import { useLogoutMutation } from '@web/store/mutation/useLogoutMutation';
+import { useSuspenseQueries } from '@tanstack/react-query';
 
 export default function Home({ params }: HomePageProps) {
   const router = useRouter();
@@ -47,20 +48,26 @@ export default function Home({ params }: HomePageProps) {
   const [scrollRef, isScrolled] = useScroll<HTMLDivElement>({
     threshold: 100,
   });
-  const { data: user } = useGetUserQuery();
-  const { data: agentDetail } = useGetAgentDetailQuery({
-    agentId: params.agentId,
+
+  const [
+    { data: user },
+    { data: agentDetail },
+    { data: agentUploadReserved },
+    { data: agentPostGroups },
+    { data: agentData },
+  ] = useSuspenseQueries({
+    queries: [
+      getUserQueryOptions(),
+      getAgentDetailQueryOptions({ agentId: params.agentId }),
+      getAgentUploadReservedQueryOptions({ agentId: params.agentId }),
+      getAgentPostGroupsQueryOptions({ agentId: params.agentId }),
+      getAgentQueryOptions(),
+    ],
   });
-  const { data: agentUploadReserved } = useGetAgentUploadReservedQuery({
-    agentId: params.agentId,
-  });
-  const { data: agentPostGroups } = useGetAgentPostGroupsQuery({
-    agentId: params.agentId,
-  });
+
   const { mutate: deletePostGroups } = useDeletePostGroupMutation({
     agentId: params.agentId,
   });
-  const { data: agentData } = useGetAgentQuery();
   const { mutate: logout } = useLogoutMutation();
 
   const userData = user.data;

--- a/apps/web/src/app/(home)/[agentId]/page.tsx
+++ b/apps/web/src/app/(home)/[agentId]/page.tsx
@@ -9,11 +9,18 @@ import {
 } from '@web/store/query/ServerFetchBoundary';
 import { HomePageProps } from './types';
 import { getUserQueryOptions } from '@web/store/query/useGetUserQuery';
+import { getAgentUploadReservedQueryOptions } from '@web/store/query/useGetAgentUploadReserved';
+import { Suspense } from 'react';
+import Loading from '@web/app/loading';
 
 export default function HomeDetailPage({ params }: HomePageProps) {
   const tokens = getServerSideTokens();
   const serverFetchOptions = [
     getAgentDetailQueryOptions({
+      agentId: params.agentId,
+      tokens,
+    }),
+    getAgentUploadReservedQueryOptions({
       agentId: params.agentId,
       tokens,
     }),
@@ -26,9 +33,10 @@ export default function HomeDetailPage({ params }: HomePageProps) {
   ];
 
   return (
-    // TODO 임시 타입 단언
     <ServerFetchBoundary fetchOptions={serverFetchOptions as FetchOptions[]}>
-      <Home params={params} />
+      <Suspense fallback={<Loading />}>
+        <Home params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/detail/EditDetail.tsx
+++ b/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/detail/EditDetail.tsx
@@ -6,7 +6,7 @@ import { EditSidebar } from './_components/EditSidebar/EditSidebar';
 import { editDetailPage, flexColumn } from './page.css';
 import { useState } from 'react';
 import { Post } from '@web/types';
-
+import { Suspense } from 'react';
 // TODO 추후 Jotai, 또는 react-query 사용으로 수정할 예정
 interface DetailPageContextType {
   loadingPosts: Post['id'][];
@@ -27,9 +27,13 @@ export function EditDetail() {
   return (
     <DetailPageContext.Provider value={{ loadingPosts, setLoadingPosts }}>
       <div className={editDetailPage}>
-        <EditSidebar />
+        <Suspense>
+          <EditSidebar />
+        </Suspense>
         <div className={flexColumn}>
-          <EditPost />
+          <Suspense>
+            <EditPost />
+          </Suspense>
         </div>
       </div>
     </DetailPageContext.Provider>

--- a/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/page.tsx
+++ b/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/page.tsx
@@ -3,6 +3,8 @@ import Edit from './Edit';
 import type { EditPageProps } from './types';
 import { getAllPostsQueryOptions } from '@web/store/query/useGetAllPostsQuery';
 import { getServerSideTokens } from '@web/shared/server/serverSideTokens';
+import { Suspense } from 'react';
+import Loading from '@web/app/loading';
 
 export default function EditPage({ params }: EditPageProps) {
   const tokens = getServerSideTokens();
@@ -14,7 +16,9 @@ export default function EditPage({ params }: EditPageProps) {
 
   return (
     <ServerFetchBoundary fetchOptions={serverFetchOptions}>
-      <Edit params={params} />
+      <Suspense fallback={<Loading />}>
+        <Edit params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/schedule/page.tsx
+++ b/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/schedule/page.tsx
@@ -3,6 +3,8 @@ import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
 import { getAllPostsQueryOptions } from '@web/store/query/useGetAllPostsQuery';
 import { getServerSideTokens } from '@web/shared/server/serverSideTokens';
 import { EditPageProps } from '../types';
+import { Suspense } from 'react';
+import Loading from '@web/app/loading';
 
 export default function SchedulePage({ params }: EditPageProps) {
   const tokens = getServerSideTokens();
@@ -14,7 +16,9 @@ export default function SchedulePage({ params }: EditPageProps) {
 
   return (
     <ServerFetchBoundary fetchOptions={serverFetchOptions}>
-      <Schedule params={params} />
+      <Suspense fallback={<Loading />}>
+        <Schedule params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/create/[agentId]/page.tsx
+++ b/apps/web/src/app/create/[agentId]/page.tsx
@@ -3,6 +3,7 @@ import { newsCategoriesQueryOptions } from '@web/store/query/useNewsCategoriesQu
 import { ServerFetchBoundary } from '@web/store/query/ServerFetchBoundary';
 import { getServerSideTokens } from '@web/shared/server/serverSideTokens';
 import { CreatePageProps } from './types';
+import { Suspense } from 'react';
 
 export default function CreatePage({ params }: CreatePageProps) {
   const tokens = getServerSideTokens();
@@ -10,7 +11,9 @@ export default function CreatePage({ params }: CreatePageProps) {
 
   return (
     <ServerFetchBoundary fetchOptions={serverFetchOptions}>
-      <Create params={params} />
+      <Suspense>
+        <Create params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/personalize/[agentId]/Personalize.tsx
+++ b/apps/web/src/app/personalize/[agentId]/Personalize.tsx
@@ -26,17 +26,17 @@ import { useModal, useToast } from '@repo/ui/hooks';
 import { useUpdatePersonalSettingMutation } from '@web/store/mutation/useUpdatePersonalSettingMutation';
 import { AccountSidebar } from '@web/components/common/AccountSidebar/AccountSidebar';
 import { ROUTES } from '@web/routes';
-import { useGetAgentQuery } from '@web/store/query/useGetAgentQuery';
+import { getAgentQueryOptions } from '@web/store/query/useGetAgentQuery';
 import { Agent } from '@web/types';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, useSuspenseQueries } from '@tanstack/react-query';
 import { MainBreadcrumbItem, NavBar } from '@web/components/common';
 import Image from 'next/image';
 import { isNil } from '@repo/ui/utils';
-import { useGetUserQuery } from '@web/store/query/useGetUserQuery';
+import { getUserQueryOptions } from '@web/store/query/useGetUserQuery';
 import { useScroll } from '@web/hooks';
 import * as style from './pageStyle.css';
 import { useLogoutMutation } from '@web/store/mutation/useLogoutMutation';
-import { useGetAgentDetailQuery } from '@web/store/query/useGetAgentDetailQuery';
+import { getAgentDetailQueryOptions } from '@web/store/query/useGetAgentDetailQuery';
 
 export default function Personalize({ params }: PersonalizePageProps) {
   const router = useRouter();
@@ -45,11 +45,15 @@ export default function Personalize({ params }: PersonalizePageProps) {
   const [scrollRef, isScrolled] = useScroll<HTMLDivElement>({
     threshold: 100,
   });
-  const { data: agentData } = useGetAgentQuery();
-  const { data: agentDetail } = useGetAgentDetailQuery({
-    agentId: params.agentId,
-  });
-  const { data: user } = useGetUserQuery();
+
+  const [{ data: agentData }, { data: agentDetail }, { data: user }] =
+    useSuspenseQueries({
+      queries: [
+        getAgentQueryOptions(),
+        getAgentDetailQueryOptions({ agentId: params.agentId }),
+        getUserQueryOptions(),
+      ],
+    });
   const { mutate: updatePersonalSetting } = useUpdatePersonalSettingMutation({
     agentId: params.agentId,
   });

--- a/apps/web/src/app/personalize/[agentId]/page.tsx
+++ b/apps/web/src/app/personalize/[agentId]/page.tsx
@@ -8,6 +8,8 @@ import { getAgentQueryOptions } from '@web/store/query/useGetAgentQuery';
 import { getUserQueryOptions } from '@web/store/query/useGetUserQuery';
 import Personalize from './Personalize';
 import { getAgentDetailQueryOptions } from '@web/store/query/useGetAgentDetailQuery';
+import { Suspense } from 'react';
+import Loading from '@web/app/loading';
 
 export default function PersonalizePage({ params }: PersonalizePageProps) {
   const tokens = getServerSideTokens();
@@ -20,7 +22,9 @@ export default function PersonalizePage({ params }: PersonalizePageProps) {
 
   return (
     <ServerFetchBoundary fetchOptions={serverFetchOptions}>
-      <Personalize params={params} />
+      <Suspense fallback={<Loading />}>
+        <Personalize params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/schedule/[agentId]/Schedule.tsx
+++ b/apps/web/src/app/schedule/[agentId]/Schedule.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { SchedulePageProps } from './type';
-import { useGetAgentUploadReservedQuery } from '@web/store/query/useGetAgentUploadReserved';
-import { useGetAgentQuery } from '@web/store/query/useGetAgentQuery';
-import { useGetUserQuery } from '@web/store/query/useGetUserQuery';
-import { useQueryClient } from '@tanstack/react-query';
+import { getAgentUploadReservedQueryOptions } from '@web/store/query/useGetAgentUploadReserved';
+import { getAgentQueryOptions } from '@web/store/query/useGetAgentQuery';
+import { getUserQueryOptions } from '@web/store/query/useGetUserQuery';
+import { useQueryClient, useSuspenseQueries } from '@tanstack/react-query';
 import * as style from './pageStyle.css';
 import {
   NavBar,
@@ -31,11 +31,15 @@ import { parseTime } from '@web/utils';
 import { useUpdateReservedPostsMutation } from '@web/store/mutation/useUpdateReservedPostsMutation';
 
 export default function Schedule({ params }: SchedulePageProps) {
-  const { data: agentData } = useGetAgentQuery();
-  const { data: user } = useGetUserQuery();
-  const { data: reservedPosts } = useGetAgentUploadReservedQuery({
-    agentId: params.agentId,
-  });
+  const [{ data: agentData }, { data: user }, { data: reservedPosts }] =
+    useSuspenseQueries({
+      queries: [
+        getAgentQueryOptions(),
+        getUserQueryOptions(),
+        getAgentUploadReservedQueryOptions({ agentId: params.agentId }),
+      ],
+    });
+
   const { mutate: updateReservedPosts } = useUpdateReservedPostsMutation(
     params.agentId
   );

--- a/apps/web/src/app/schedule/[agentId]/[postGroupId]/[postId]/ScheduleDetail.tsx
+++ b/apps/web/src/app/schedule/[agentId]/[postGroupId]/[postId]/ScheduleDetail.tsx
@@ -15,27 +15,31 @@ import {
 } from '@repo/ui';
 import Image from 'next/image';
 import { ScheduleDetailPageProps } from './type';
-import { useGetPostQuery } from '@web/store/query/useGetPostQuery';
+import { getPostQueryOptions } from '@web/store/query/useGetPostQuery';
 import { isNil } from '@repo/ui/utils';
 import { ROUTES } from '@web/routes';
-import { useGetTopicQuery } from '@web/store/query/useGetTopicQuery';
+import { getTopicQueryOptions } from '@web/store/query/useGetTopicQuery';
 import { useDeletePostMutation } from '@web/store/mutation/useDeletePostMutation';
 import { useModal } from '@repo/ui/hooks';
+import { useSuspenseQueries } from '@tanstack/react-query';
 
 export default function ScheduleDetail({ params }: ScheduleDetailPageProps) {
   const [scrollRef, isScrolled] = useScroll<HTMLDivElement>({ threshold: 100 });
   const router = useRouter();
   const modal = useModal();
 
-  const { data: post } = useGetPostQuery({
-    agentId: Number(params.agentId),
-    postGroupId: Number(params.postGroupId),
-    postId: Number(params.postId),
-  });
-
-  const { data: topic } = useGetTopicQuery({
-    agentId: Number(params.agentId),
-    postGroupId: Number(params.postGroupId),
+  const [{ data: post }, { data: topic }] = useSuspenseQueries({
+    queries: [
+      getPostQueryOptions({
+        agentId: Number(params.agentId),
+        postGroupId: Number(params.postGroupId),
+        postId: Number(params.postId),
+      }),
+      getTopicQueryOptions({
+        agentId: Number(params.agentId),
+        postGroupId: Number(params.postGroupId),
+      }),
+    ],
   });
 
   const { mutate: deletePost } = useDeletePostMutation({

--- a/apps/web/src/app/schedule/[agentId]/[postGroupId]/[postId]/page.tsx
+++ b/apps/web/src/app/schedule/[agentId]/[postGroupId]/[postId]/page.tsx
@@ -7,6 +7,8 @@ import { getServerSideTokens } from '@web/shared/server/serverSideTokens';
 import { ScheduleDetailPageProps } from './type';
 import { getPostQueryOptions } from '@web/store/query/useGetPostQuery';
 import { getTopicQueryOptions } from '@web/store/query/useGetTopicQuery';
+import { Suspense } from 'react';
+import Loading from '@web/app/loading';
 
 export default function ScheduleDetailPage({
   params,
@@ -28,7 +30,9 @@ export default function ScheduleDetailPage({
 
   return (
     <ServerFetchBoundary fetchOptions={serverFetchOptions}>
-      <ScheduleDetail params={params} />
+      <Suspense fallback={<Loading />}>
+        <ScheduleDetail params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }

--- a/apps/web/src/app/schedule/[agentId]/page.tsx
+++ b/apps/web/src/app/schedule/[agentId]/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Suspense } from 'react';
 import Schedule from './Schedule';
 import { SchedulePageProps } from './type';
 import { getServerSideTokens } from '@web/shared/server/serverSideTokens';
@@ -9,6 +9,7 @@ import {
   ServerFetchBoundary,
 } from '@web/store/query/ServerFetchBoundary';
 import { getAgentUploadReservedQueryOptions } from '@web/store/query/useGetAgentUploadReserved';
+import Loading from '@web/app/loading';
 
 export default function SchedulePage({ params }: SchedulePageProps) {
   const tokens = getServerSideTokens();
@@ -21,7 +22,9 @@ export default function SchedulePage({ params }: SchedulePageProps) {
 
   return (
     <ServerFetchBoundary fetchOptions={serverFetchOptions}>
-      <Schedule params={params} />
+      <Suspense fallback={<Loading />}>
+        <Schedule params={params} />
+      </Suspense>
     </ServerFetchBoundary>
   );
 }


### PR DESCRIPTION
## 관련 이슈

close: #173 

## 변경 사항
useSuspenseQuery를 여러개 사용하는 곳에서의 폭포수를 개선하고, useSuspenseQuery 및 useSuspenseQueries를 사용하는 곳에서 Suspense boundary 래핑을 진행합니다.

간단히 테스트를 해보기 위해, client side에서 호출하는 모습을 확인해보았어요.

### AS-IS

<img width="722" alt="image" src="https://github.com/user-attachments/assets/b2ada1c7-5909-4b59-8381-97dcb5d72342" />

https://github.com/user-attachments/assets/a9b57840-b835-4fd2-8053-a4196b5d24fc



### TO-BE

<img width="647" alt="image" src="https://github.com/user-attachments/assets/611fefbd-5767-4a86-9a9b-e3948ba363a9" />

https://github.com/user-attachments/assets/7db236ef-cd4a-4dcb-a277-d8cb76b092d5




## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 비동기 데이터 로딩 동안 사용자에게 로딩 상태를 명확하게 보여주는 피드백 기능이 추가되었습니다.
  
- **리팩터**
  - 여러 데이터 요청을 하나의 통합 처리 방식으로 전환하여, 여러 정보를 동시에 효율적으로 불러오도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->