### PR TITLE
[Feat] Toast에 toastPosition api 제공

### DIFF
--- a/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/detail/_components/EditSidebar/EditSidebar.tsx
+++ b/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/detail/_components/EditSidebar/EditSidebar.tsx
@@ -23,7 +23,7 @@ import { Post, POST_STATUS } from '@web/types/post';
 import { IconButton } from '@repo/ui/IconButton';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { useCreateMorePostsMutation } from '@web/store/mutation/useCreateMorePostsMutation';
-import { useModal, useToast } from '@repo/ui/hooks';
+import { useModal } from '@repo/ui/hooks';
 import { Modal } from '@repo/ui/Modal';
 import { useDeletePostMutation } from '@web/store/mutation/useDeletePostMutation';
 import { DetailPageContext } from '../../EditDetail';
@@ -43,7 +43,6 @@ import { isEmptyStringOrNil } from '@web/utils';
 
 function EditSidebarContent() {
   const modal = useModal();
-  const toast = useToast();
   const { loadingPosts, setLoadingPosts } = useContext(DetailPageContext);
   const { agentId, postGroupId } = useParams();
   const router = useRouter();

--- a/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/detail/_components/PostEditor/PostEditor.tsx
+++ b/apps/web/src/app/(prompt)/edit/[agentId]/[postGroupId]/detail/_components/PostEditor/PostEditor.tsx
@@ -147,7 +147,9 @@ export function PostEditor() {
     const existingImageUrls = watch('imageUrls') || [];
 
     if (existingImageUrls.length + files.length > maxFiles) {
-      toast.error(`이미지는 최대 ${maxFiles}장까지 업로드할 수 있어요.`, 3000);
+      toast.error(`이미지는 최대 ${maxFiles}장까지 업로드할 수 있어요.`, {
+        duration: 3000,
+      });
       return;
     }
 

--- a/apps/web/src/app/create/[agentId]/Create.tsx
+++ b/apps/web/src/app/create/[agentId]/Create.tsx
@@ -24,7 +24,7 @@ import {
   LENGTH_OPTIONS,
 } from './constants';
 import * as styles from './pageStyle.css';
-import { useModal, useToast } from '@repo/ui/hooks';
+import { useModal } from '@repo/ui/hooks';
 import { useRouter } from 'next/navigation';
 import { useNewsCategoriesQuery } from '@web/store/query/useNewsCategoriesQuery';
 import { isNotNil } from '@repo/ui/utils';
@@ -45,7 +45,6 @@ export default function Create({ params }: CreatePageProps) {
     agentId: params.agentId,
   });
   const modal = useModal();
-  const toast = useToast();
   const router = useRouter();
   const [scrollRef, isScrolled] = useScroll<HTMLDivElement>({
     threshold: 100,
@@ -146,13 +145,7 @@ export default function Create({ params }: CreatePageProps) {
       <Spacing size={80} />
 
       <AnimatedTitle>어떤 글을 생성할까요?</AnimatedTitle>
-      <button
-        onClick={() =>
-          toast.success('안녕하세요', { duration: 3000, toastPosition: 'top' })
-        }
-      >
-        토스트 띄우기
-      </button>
+
       <AnimatedContainer>
         <form className={styles.contentStyle}>
           {/* 주제 */}

--- a/apps/web/src/app/create/[agentId]/Create.tsx
+++ b/apps/web/src/app/create/[agentId]/Create.tsx
@@ -24,7 +24,7 @@ import {
   LENGTH_OPTIONS,
 } from './constants';
 import * as styles from './pageStyle.css';
-import { useModal } from '@repo/ui/hooks';
+import { useModal, useToast } from '@repo/ui/hooks';
 import { useRouter } from 'next/navigation';
 import { useNewsCategoriesQuery } from '@web/store/query/useNewsCategoriesQuery';
 import { isNotNil } from '@repo/ui/utils';
@@ -45,6 +45,7 @@ export default function Create({ params }: CreatePageProps) {
     agentId: params.agentId,
   });
   const modal = useModal();
+  const toast = useToast();
   const router = useRouter();
   const [scrollRef, isScrolled] = useScroll<HTMLDivElement>({
     threshold: 100,
@@ -145,7 +146,13 @@ export default function Create({ params }: CreatePageProps) {
       <Spacing size={80} />
 
       <AnimatedTitle>어떤 글을 생성할까요?</AnimatedTitle>
-
+      <button
+        onClick={() =>
+          toast.success('안녕하세요', { duration: 3000, toastPosition: 'top' })
+        }
+      >
+        토스트 띄우기
+      </button>
       <AnimatedContainer>
         <form className={styles.contentStyle}>
           {/* 주제 */}

--- a/packages/ui/src/components/Toast/Toast.css.ts
+++ b/packages/ui/src/components/Toast/Toast.css.ts
@@ -1,15 +1,32 @@
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 import { style } from '@vanilla-extract/css';
 import { vars } from '@repo/theme';
 
-export const container = style({
-  position: 'fixed',
-  bottom: 40,
-  right: 40,
-  padding: `${vars.space[20]} ${vars.space[32]}`,
-  borderRadius: 100,
-  backgroundColor: vars.colors.grey700,
-  color: vars.colors.grey,
+export const container = recipe({
+  base: {
+    position: 'fixed',
+    right: 24,
+    padding: `${vars.space[20]} ${vars.space[32]}`,
+    borderRadius: 100,
+    backgroundColor: vars.colors.grey700,
+    color: vars.colors.grey,
+  },
+  variants: {
+    toastPosition: {
+      top: {
+        top: 24,
+      },
+      bottom: {
+        bottom: 24,
+      },
+    },
+  },
+  defaultVariants: {
+    toastPosition: 'bottom',
+  },
 });
+
+export type ContainerVariants = RecipeVariants<typeof container>;
 
 export const content = style({
   display: 'flex',

--- a/packages/ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/src/components/Toast/Toast.tsx
@@ -21,6 +21,11 @@ export type ToastProps = {
    */
   toastType?: ToastType;
   /**
+   * 토스트 위치
+   * @default 'bottom'
+   */
+  toastPosition?: 'top' | 'bottom';
+  /**
    * 왼쪽 추가 요소 (아이콘 등)
    */
   leftAddon?: ReactNode;
@@ -55,6 +60,7 @@ const ToastComponent = forwardRef<HTMLDivElement, ToastProps>(
   (
     {
       toastType = 'default',
+      toastPosition = 'top',
       leftAddon,
       duration = 2000,
       children,
@@ -92,10 +98,16 @@ const ToastComponent = forwardRef<HTMLDivElement, ToastProps>(
         {open && (
           <motion.div
             ref={mergeRefs(ref, toastRef)}
-            className={styles.container}
-            initial={{ y: '120%', opacity: 0 }}
+            className={styles.container({ toastPosition })}
+            initial={{
+              y: toastPosition === 'top' ? '-120%' : '120%',
+              opacity: 0,
+            }}
             animate={{ y: 0, opacity: 1 }}
-            exit={{ y: '120%', opacity: 0 }}
+            exit={{
+              y: toastPosition === 'top' ? '-120%' : '120%',
+              opacity: 0,
+            }}
             transition={{
               type: 'spring',
               damping: 25,

--- a/packages/ui/src/hooks/useToast.tsx
+++ b/packages/ui/src/hooks/useToast.tsx
@@ -3,7 +3,7 @@
 import { useCallback } from 'react';
 import { overlay } from 'overlay-kit';
 import { Toast, Icon } from '../components';
-import type { ToastType } from '../components/Toast/Toast';
+import type { ToastProps, ToastType } from '../components/Toast/Toast';
 import type { LottieAnimationProps } from '../components/LottieAnimation/LottieAnimation';
 import type { IconProps } from '../components/Icon/Icon';
 import { isNil, isNotNil } from '../utils';
@@ -19,8 +19,9 @@ type IconAddon = {
   props: IconProps;
 };
 
-type ToastOptions = {
-  duration: number;
+type ToastOptions = Partial<
+  Pick<ToastProps, 'duration' | 'leftAddon' | 'toastPosition'>
+> & {
   leftAddon?: LottieAddon | IconAddon;
 };
 
@@ -30,19 +31,24 @@ const DEFAULT_DURATION = 3000;
  * 토스트 메시지를 표시하기 위한 커스텀 훅
  *
  * @example
+ * // 토스트 위치 설정
+ * const toast = useToast();
+ * toast.success('생성된 본문이 업데이트 됐어요!', {toastPosition: 'top'});
+ *
+ * @example
  * // 기본 성공 토스트
  * const toast = useToast();
- * toast.success('생성된 본문이 업데이트 됐어요!', 3000);
+ * toast.success('생성된 본문이 업데이트 됐어요!', {duration: 3000});
  *
  * @example
  * // 기본 에러 토스트
  * const toast = useToast();
- * toast.error('생성된 본문이 업데이트 됐어요!', 3000);
+ * toast.error('생성된 본문이 업데이트 됐어요!', {duration: 3000});
  *
  * @example
  * // 기본 default 토스트
  * const toast = useToast();
- * toast.default('생성된 본문이 업데이트 됐어요!', 3000);
+ * toast.default('생성된 본문이 업데이트 됐어요!', {duration: 3000});
  *
  * @example
  * // Lottie 애니메이션이 있는 커스텀 토스트
@@ -81,7 +87,7 @@ export function useToast() {
     (
       text: string,
       toastType: ToastType = 'default',
-      duration = DEFAULT_DURATION
+      options: ToastOptions = {}
     ) => {
       return overlay.open(({ isOpen, close, unmount }) => (
         <Toast
@@ -91,7 +97,8 @@ export function useToast() {
           leftAddon={
             toastType !== 'default' && <Toast.Icon toastType={toastType} />
           }
-          duration={duration}
+          duration={options.duration ?? DEFAULT_DURATION}
+          toastPosition={options.toastPosition}
         >
           {text}
         </Toast>
@@ -100,47 +107,46 @@ export function useToast() {
     []
   );
 
-  const custom = useCallback(
-    (text: string, options: Partial<ToastOptions> = {}) => {
-      const leftAddonType = options.leftAddon?.type;
+  const custom = useCallback((text: string, options: ToastOptions = {}) => {
+    const leftAddonType = options.leftAddon?.type;
 
-      const leftAddonElement = (() => {
-        if (isNil(options.leftAddon)) return null;
+    const leftAddonElement = (() => {
+      if (isNil(options.leftAddon)) return null;
 
-        switch (leftAddonType) {
-          case 'lottie':
-            return <DynamicLottie {...options.leftAddon.props} />;
-          case 'icon':
-            return <Icon {...options.leftAddon.props} />;
-          case undefined:
-            return null;
+      switch (leftAddonType) {
+        case 'lottie':
+          return <DynamicLottie {...options.leftAddon.props} />;
+        case 'icon':
+          return <Icon {...options.leftAddon.props} />;
+        case undefined:
+          return null;
+      }
+      leftAddonType satisfies never;
+    })();
+
+    return overlay.open(({ isOpen, close, unmount }) => (
+      <Toast
+        open={isOpen}
+        onClose={close}
+        onExited={unmount}
+        leftAddon={leftAddonElement}
+        duration={
+          isNotNil(options.duration) ? options.duration : DEFAULT_DURATION
         }
-        leftAddonType satisfies never;
-      })();
-
-      return overlay.open(({ isOpen, close, unmount }) => (
-        <Toast
-          open={isOpen}
-          onClose={close}
-          onExited={unmount}
-          leftAddon={leftAddonElement}
-          duration={
-            isNotNil(options.duration) ? options.duration : DEFAULT_DURATION
-          }
-        >
-          {text}
-        </Toast>
-      ));
-    },
-    []
-  );
+        toastPosition={options.toastPosition}
+      >
+        {text}
+      </Toast>
+    ));
+  }, []);
 
   return {
-    success: (text: string, duration?: number) =>
-      show(text, 'success', duration),
-    error: (text: string, duration?: number) => show(text, 'error', duration),
-    default: (text: string, duration?: number) =>
-      show(text, 'default', duration),
+    success: (text: string, options?: ToastOptions) =>
+      show(text, 'success', options),
+    error: (text: string, options?: ToastOptions) =>
+      show(text, 'error', options),
+    default: (text: string, options?: ToastOptions) =>
+      show(text, 'default', options),
     custom,
   } as const;
 }


### PR DESCRIPTION
## 관련 이슈

close: #177 

## 변경 사항

아래에서 나오는 Toast로만 제공하다, 다지인 요구사항으로 인해 top, bottom 두 가지 옵션을 제공합니다.

## 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 토스트 알림의 위치를 상단 또는 하단으로 지정할 수 있는 옵션이 추가되었습니다.
  - 토스트 알림에 Lottie 또는 아이콘을 왼쪽에 추가할 수 있습니다.

- **버그 수정**
  - 이미지 업로드 제한 초과 시 토스트 알림의 표시 방식이 개선되었습니다.

- **스타일**
  - 토스트 알림의 위치와 여백이 조정되어 더욱 다양한 위치에서 표시됩니다.

- **리팩터**
  - 토스트 관련 옵션 전달 방식이 숫자(duration)에서 옵션 객체로 변경되어, 더 유연한 설정이 가능합니다.

- **기타**
  - 불필요한 토스트 훅 사용이 일부 컴포넌트에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->